### PR TITLE
Do not play animation in init

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CheckstyleConfigurable">
     <option name="suppFilterFilename" value="" />

--- a/app/src/main/java/org/akanework/gramophone/ui/components/PlayerBottomSheet.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/components/PlayerBottomSheet.kt
@@ -217,7 +217,7 @@ class PlayerBottomSheet private constructor(
 			it.phaseSpeed = seekBarProgressPhase
 			it.strokeWidth = seekBarProgressStrokeWidth
 			it.transitionEnabled = true
-			it.animate = true
+			it.animate = false
 			it.setTint(
 				MaterialColors.getColor(
 					bottomSheetFullSlider,


### PR DESCRIPTION
 * We don't want SquigglyProgress to play animations that it shouldn't be playing during the init phase, since the player should be paused at this point when it's first started.