### PR TITLE
Fix Album Sorting for multiple Discs

### DIFF
--- a/app/src/main/java/org/akanework/gramophone/ui/fragments/GeneralSubFragment.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/fragments/GeneralSubFragment.kt
@@ -41,7 +41,7 @@ class GeneralSubFragment : BaseFragment(true) {
                 val item = libraryViewModel.albumItemList.value!![position]
                 title = item.title ?: requireContext().getString(R.string.unknown_album)
                 itemList = item.songList
-                helper = Sorter.NaturalOrderHelper { it.mediaMetadata.trackNumber!! }
+                helper = Sorter.NaturalOrderHelper { it.mediaMetadata.trackNumber!! + it.mediaMetadata.discNumber!! * 1000 }
             }
 
             /*R.id.artist -> {


### PR DESCRIPTION
When an album has multiple discs, then it will not sort the items correctly, 
because there will be multiple songs with the same track.

This patch tries to alleviate that, without adding any new logic