### PR TITLE
Mark translated lines properly on "compressed" LRC

### DIFF
--- a/app/src/main/kotlin/org/akanework/gramophone/logic/utils/MediaStoreUtils.kt
+++ b/app/src/main/kotlin/org/akanework/gramophone/logic/utils/MediaStoreUtils.kt
@@ -114,7 +114,7 @@ object MediaStoreUtils {
     data class Lyric(
         val timeStamp: Long = 0,
         val content: String = "",
-        val isTranslation: Boolean = false
+        var isTranslation: Boolean = false
     ) : Parcelable
 
     class RecentlyAdded(minAddDate: Long, songList: PriorityQueue<Pair<Long, MediaItem>>) : Playlist(


### PR DESCRIPTION
As on the previous implementations, we can no longer rely on `Collections.binarySearch()` for marking lines as translated because that function assumes **our origin IS already sorted**, which won't be the case on "compressed" LRC, because duplicates will be inserted in the declared order, scrambling evertyhing around.

The approach now is: insert on a loop as fast as we can, sort outside that loop and make a second loop pass looking for duplicate timestamps on the already sorted list and marking as translations any one found. Also, the flag for translated lyrics is now a `var` to modify it on the second pass instead of inserting again.