### PR TITLE
Gramophone: Upgrade AGP version to `8.4.0-rc01`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.3.1" apply false
+    id("com.android.application") version "8.4.0-rc01" apply false
     val kotlinVersion = "2.0.0-Beta5"
     id("org.jetbrains.kotlin.android") version kotlinVersion apply false
     id("com.google.devtools.ksp") version "$kotlinVersion-1.0.20" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Wed Aug 02 13:28:37 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
+distributionSha256Sum=9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c


### PR DESCRIPTION
Test: Build, launch app, play music

Change-Id: I0a92fee12dd80be062195ca63a6a17fa118ebfd4