### PR TITLE
Add shuffle all option in home menu - closes #313

### DIFF
--- a/app/src/main/kotlin/org/akanework/gramophone/ui/adapters/BaseDecorAdapter.kt
+++ b/app/src/main/kotlin/org/akanework/gramophone/ui/adapters/BaseDecorAdapter.kt
@@ -34,7 +34,6 @@ import org.akanework.gramophone.R
 import org.akanework.gramophone.logic.ui.ItemHeightHelper
 import org.akanework.gramophone.logic.ui.MyRecyclerView
 import org.akanework.gramophone.ui.getAdapterType
-import kotlin.random.Random
 
 open class BaseDecorAdapter<T : BaseAdapter<*>>(
     protected val adapter: T,
@@ -178,7 +177,6 @@ open class BaseDecorAdapter<T : BaseAdapter<*>>(
                 controller?.shuffleModeEnabled = true
                 list.takeIf { it.isNotEmpty() }?.also {
                     controller?.setMediaItems(it)
-                    controller?.seekToDefaultPosition(Random.nextInt(0, it.size))
                     controller?.prepare()
                     controller?.play()
                 } ?: controller?.setMediaItems(listOf())

--- a/app/src/main/kotlin/org/akanework/gramophone/ui/fragments/ViewPagerFragment.kt
+++ b/app/src/main/kotlin/org/akanework/gramophone/ui/fragments/ViewPagerFragment.kt
@@ -162,6 +162,15 @@ class ViewPagerFragment : BaseFragment(true) {
                 R.id.settings -> {
                     (requireActivity() as MainActivity).startFragment(MainSettingsFragment())
                 }
+                R.id.shuffle -> {
+                    val controller = (requireActivity() as MainActivity).getPlayer()
+                    libraryViewModel.mediaItemList.value?.takeIf { it.isNotEmpty() }?.also {
+                        controller?.shuffleModeEnabled = true
+                        controller?.setMediaItems(it)
+                        controller?.prepare()
+                        controller?.play()
+                    } ?: controller?.setMediaItems(listOf())
+                }
 
                 else -> throw IllegalStateException()
             }

--- a/app/src/main/res/menu/home_menu.xml
+++ b/app/src/main/res/menu/home_menu.xml
@@ -21,4 +21,9 @@
         android:icon="@drawable/ic_settings"
         android:title="@string/home_menu_settings"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/shuffle"
+        android:icon="@drawable/ic_shuffle"
+        android:title="@string/home_menu_shuffle"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <!-- Translatable -->
     <string name="home_menu_search">Search</string>
     <string name="home_menu_settings">Settings</string>
+    <string name="home_menu_shuffle">Shuffle all</string>
     <string name="home_menu_refresh">Refresh</string>
     <string name="category_songs">Songs</string>
     <string name="category_albums">Albums</string>


### PR DESCRIPTION
- Adds a "shuffle all" option to the three dot menu.
- Fixes a bug with the shuffle all button in the songs fragment skipping some songs.