### PR TITLE
Hide null bit depth in player

### DIFF
--- a/app/src/main/kotlin/org/akanework/gramophone/ui/components/FullBottomSheet.kt
+++ b/app/src/main/kotlin/org/akanework/gramophone/ui/components/FullBottomSheet.kt
@@ -702,8 +702,10 @@ class FullBottomSheet
         }
 
         bottomSheetFullQualityDetails.text = buildString {
-            append("${info.bitDepth}bit")
-            append(" / ${info.sampleRate / 1000f}kHz")
+            info.bitDepth?.let {
+                append("${it}bit / ")
+            }
+            append("${info.sampleRate / 1000f}kHz")
             append(" / $channelInfo")
             info.bitrate?.let {
                 append(" / ${it / 1000}kbps")


### PR DESCRIPTION
Some audio formats (like mp3 and m4a) uses lossy codecs so the bit depth is lost. Currently the player displays "nullbit", so we conditionally render the bit depth if the information is present. 