### PR TITLE
update readme to use horizontal translation status badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 
 ## Translation
 <a href="https://hosted.weblate.org/engage/gramophone/">
-<img src="https://hosted.weblate.org/widget/gramophone/strings-xml/287x66-white.png" alt="Translation status" />
+<img src="https://hosted.weblate.org/widget/gramophone/strings-xml/horizontal-auto.svg" alt="Translation status" />
 </a>
 
 ## Notice

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -51,7 +51,7 @@ Gramophone には、アプリのパッケージを示すためのパッケージ
 
 ## 翻訳
 <a href="https://hosted.weblate.org/engage/gramophone/">
-<img src="https://hosted.weblate.org/widget/gramophone/strings-xml/287x66-white.png" alt="Translation status" />
+<img src="https://hosted.weblate.org/widget/gramophone/strings-xml/horizontal-auto.svg" alt="Translation status" />
 </a>
 
 ## お知らせ


### PR DESCRIPTION
Update README to use horizontal translation status badge.

### Before

<img width="329" height="151" alt="image" src="https://github.com/user-attachments/assets/04598341-e8c9-43c3-8b92-2305d3b3629e" />

### After

<img width="683" height="396" alt="image" src="https://github.com/user-attachments/assets/1b7a4bc2-1d91-4eac-b66b-745a126af65b" />