### PR TITLE
Switch Media3 module import method

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,6 @@
 
 import com.android.build.api.dsl.ApplicationBuildType
 import com.android.build.gradle.tasks.PackageAndroidArtifact
-import org.gradle.kotlin.dsl.support.kotlinCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.util.removeSuffixIfPresent
 import java.util.Properties
@@ -286,11 +285,15 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.8.8")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
     implementation("androidx.mediarouter:mediarouter:1.8.0")
-    val media3Version = "1.7.1"
-    implementation("androidx.media3:media3-common-ktx:$media3Version")
-    implementation("androidx.media3:media3-exoplayer:$media3Version")
-    implementation("androidx.media3:media3-exoplayer-midi:$media3Version")
-    implementation("androidx.media3:media3-session:$media3Version")
+//    val media3Version = "1.7.1"
+//    implementation("androidx.media3:media3-common-ktx:$media3Version")
+//    implementation("androidx.media3:media3-exoplayer:$media3Version")
+//    implementation("androidx.media3:media3-exoplayer-midi:$media3Version")
+//    implementation("androidx.media3:media3-session:$media3Version")
+    implementation(project(":media3-lib-exoplayer"))
+    implementation(project(":media3-lib-decoder-midi"))
+    implementation(project(":media3-lib-session"))
+    implementation(project(":media3-lib-common-ktx"))
     //implementation("androidx.navigation:navigation-fragment-ktx:2.7.7") TODO consider it
     //implementation("androidx.paging:paging-runtime-ktx:3.2.1") TODO paged, partial, flow based library loading
     //implementation("androidx.paging:paging-guava:3.2.1") TODO do we have guava? do we need this?

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,10 @@ pluginManagement {
     }
 }
 
+gradle.extra.apply {
+    set("androidxMediaEnableMidiModule", true)
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -22,13 +26,6 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "Gramophone"
-includeBuild(file("media3").toPath().toRealPath().toAbsolutePath().toString()) {
-    dependencySubstitution {
-        substitute(module("androidx.media3:media3-common")).using(project(":lib-common"))
-        substitute(module("androidx.media3:media3-common-ktx")).using(project(":lib-common-ktx"))
-        substitute(module("androidx.media3:media3-exoplayer")).using(project(":lib-exoplayer"))
-        substitute(module("androidx.media3:media3-exoplayer-midi")).using(project(":lib-decoder-midi"))
-        substitute(module("androidx.media3:media3-session")).using(project(":lib-session"))
-    }
-}
+(gradle as ExtensionAware).extra["androidxMediaModulePrefix"] = "media3-"
+apply(from = file("media3/core_settings.gradle"))
 include(":hificore", ":app", ":baselineprofile")


### PR DESCRIPTION
This commit enables the `androidxMediaEnableMidiModule` flag in `settings.gradle.kts` and switches the Media3 module import method.

Specifically:
- `settings.gradle.kts`:
- Set `gradle.extra[“androidxMediaEnableMidiModule”] = true`.
- Replace the `includeBuild` block for Media3 with `(gradle as ExtensionAware).extra[“androidxMediaModulePrefix”] = “media3-”` and `apply(from = file(“media3/core_settings.gradle”))`. This allows Media3 subprojects to be included in a more standard way.
- `app/build.gradle.kts`:
- Replace remote Media3 dependencies with local project dependencies (e.g., `implementation(project(“:media3-lib-exoplayer”))`).