### PR TITLE
Fix lyrics parsing actual lyrics lines as translations for a blank lyric line

### DIFF
--- a/app/src/main/java/org/akanework/gramophone/logic/utils/SemanticLyrics.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/SemanticLyrics.kt
@@ -717,13 +717,13 @@ fun parseLrc(lyricText: String, trimEnabled: Boolean, multiLineEnabled: Boolean)
         }
     }
     out.sortBy { it.start }
-    var previousTimestamp = ULong.MAX_VALUE
+    var previousLyric: LyricLine? = null
     val defaultIsWalaokeM = out.find { it.speaker?.isWalaoke == true } != null &&
             out.find { it.speaker?.isWalaoke == false } == null
     out.forEach { lyric ->
         if (defaultIsWalaokeM && lyric.speaker == null)
             lyric.speaker = SpeakerEntity.Male
-        val mainEnd = if (lyric.start == previousTimestamp) out.firstOrNull {
+        val mainEnd = if (lyric.start == previousLyric?.start) out.firstOrNull {
             it.start == lyric.start && !it.endIsImplicit }?.end else null
         if (lyric.endIsImplicit) {
             if (mainEnd != null) {
@@ -734,8 +734,9 @@ fun parseLrc(lyricText: String, trimEnabled: Boolean, multiLineEnabled: Boolean)
                     ?: Long.MAX_VALUE.toULong()
             }
         }
-        lyric.isTranslated = lyric.start == previousTimestamp
-        previousTimestamp = lyric.start
+        lyric.isTranslated = lyric.start == previousLyric?.start &&
+                (previousLyric.text.isNotBlank() || lyric.text.isBlank())
+        previousLyric = lyric
     }
     while (out.firstOrNull()?.text?.isBlank() == true)
         out.removeAt(0)

--- a/app/src/test/java/org/akanework/gramophone/LrcTestData.kt
+++ b/app/src/test/java/org/akanework/gramophone/LrcTestData.kt
@@ -324,7 +324,7 @@ object LrcTestData {
 [00:13.000]In the shape of an "L" on her forehead
 [00:18.300]Well, the hits start coming and they don't stop coming
 [00:21.600]Head to the rules and ya hit the ground running
-[00:24.300]Didn't make sense just to live for fun,
+[00:24.300]
 [00:26.300]You're brain gets smart but your head gets dumb
 [00:28.600]So much to do so much to see
 [00:30.600]So what's wrong with takin the backstreets
@@ -377,7 +377,7 @@ object LrcTestData {
 [00:13.000]她手指在额头前摆出的“L”的形状
 [00:18.300]好了 新的时代正在来临 他们无法阻止
 [00:21.600]早已厌烦了老套的规则  奔跑着用双脚撞击地面
-[00:24.300]没有意义只是为了好玩
+[00:24.300]
 [00:26.300]你的大脑变得又聪明又愚蠢
 [00:28.600]那么多事要做 那么多话要说
 [00:30.600]让我们代替后街男孩又如何
@@ -435,8 +435,8 @@ object LrcTestData {
 		LyricLine(start = 18300uL, text = """好了 新的时代正在来临 他们无法阻止""", words = null, speaker = null, end = 21599uL, isTranslated = true, endIsImplicit = true),
 		LyricLine(start = 21600uL, text = """Head to the rules and ya hit the ground running""", words = null, speaker = null, end = 24299uL, isTranslated = false, endIsImplicit = true),
 		LyricLine(start = 21600uL, text = """早已厌烦了老套的规则  奔跑着用双脚撞击地面""", words = null, speaker = null, end = 24299uL, isTranslated = true, endIsImplicit = true),
-		LyricLine(start = 24300uL, text = """Didn't make sense just to live for fun,""", words = null, speaker = null, end = 26299uL, isTranslated = false, endIsImplicit = true),
-		LyricLine(start = 24300uL, text = """没有意义只是为了好玩""", words = null, speaker = null, end = 26299uL, isTranslated = true, endIsImplicit = true),
+		LyricLine(start = 24300uL, text = """""", words = null, speaker = null, end = 26299uL, isTranslated = false, endIsImplicit = true),
+		LyricLine(start = 24300uL, text = """""", words = null, speaker = null, end = 26299uL, isTranslated = true, endIsImplicit = true),
 		LyricLine(start = 26300uL, text = """You're brain gets smart but your head gets dumb""", words = null, speaker = null, end = 28599uL, isTranslated = false, endIsImplicit = true),
 		LyricLine(start = 26300uL, text = """你的大脑变得又聪明又愚蠢""", words = null, speaker = null, end = 28599uL, isTranslated = true, endIsImplicit = true),
 		LyricLine(start = 28600uL, text = """So much to do so much to see""", words = null, speaker = null, end = 30599uL, isTranslated = false, endIsImplicit = true),

--- a/app/src/test/java/org/akanework/gramophone/LrcUtilsTest.kt
+++ b/app/src/test/java/org/akanework/gramophone/LrcUtilsTest.kt
@@ -3,6 +3,7 @@ package org.akanework.gramophone
 import androidx.media3.common.MimeTypes
 import org.akanework.gramophone.logic.utils.LrcUtils
 import org.akanework.gramophone.logic.utils.SemanticLyrics
+import org.akanework.gramophone.logic.utils.SemanticLyrics.LyricLine
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -230,6 +231,29 @@ class LrcUtilsTest {
 		assertEquals("hello\ngood morning", lrc[1].text)
 		assertEquals(204uL, lrc[1].start)
 	}
+
+    @Test
+    fun testEmptyLyricNoTranslation() {
+        val lrc = parseSynced("[00:00.29]It's hard to breathe but that's alright\n[00:04.45]\n[00:04.45]Hush\n[00:14.23]\n[00:16.25]Shh")
+        assertNotNull(lrc)
+        assertEquals(5, lrc!!.size)
+
+        assertEquals("It's hard to breathe but that's alright", lrc[0].text)
+        assertEquals(290uL, lrc[0].start)
+        assertEquals(false, lrc[0].isTranslated)
+        assertEquals("", lrc[1].text)
+        assertEquals(4450uL, lrc[1].start)
+        assertEquals(false, lrc[1].isTranslated)
+        assertEquals("Hush", lrc[2].text)
+        assertEquals(4450uL, lrc[2].start)
+        assertEquals(false, lrc[2].isTranslated)
+        assertEquals("", lrc[3].text)
+        assertEquals(14230uL, lrc[3].start)
+        assertEquals(false, lrc[3].isTranslated)
+        assertEquals("Shh", lrc[4].text)
+        assertEquals(16250uL, lrc[4].start)
+        assertEquals(false, lrc[4].isTranslated)
+    }
 
 	@Test
 	fun testOnlyWordSyncPoints() {


### PR DESCRIPTION
Some lyrics providers have lyrics that use duplicated timestamps for formatting reasons, causing the blank line to be parsed as the main lyric, and the second (actual line) to be parsed as a translation. After this change, blank lines will not be eligible for translation.

See the following for an example without translations:
```
[00:23.73]I see the world through eyes covered in ink and bleach [00:29.70]Cross out the ones who heard my cries and watched me weep [00:35.64]
[00:35.64]I love everything
[00:38.51]Fire's spreading all around my room
[00:43.13]My world's so bright
[00:44.42]It's hard to breathe but that's alright
[00:47.32]Hush
[00:59.22]
[00:59.22]Shh
[01:11.46]
[01:11.46]Tape my eyes open to force reality (oh no, no) [01:17.99]Why can't you just let me eat my weight in glee?
```


| Before     | After       | 
|----------------------------|---------------------------------------------|
|      <img width="300" alt="Screenshot_20250816_143258" src="https://github.com/user-attachments/assets/c80c81f8-3dbd-4793-984e-c7d40497bd6e" /> |   <img width="300"  alt="Screenshot_20250816_143348" src="https://github.com/user-attachments/assets/f2414485-c0e2-4ffe-ac41-7841b6067ad0"  /> |



Lmk if you want me to write tests for this