### PR TITLE
feat: Added Music Island sharing support for Xiaomi's Hyper OS

### DIFF
--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -191,7 +191,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
     private val scope = CoroutineScope(Dispatchers.Default)
     private val lyricsFetcher = CoroutineScope(Dispatchers.IO.limitedParallelism(1))
     private val bitrateFetcher = CoroutineScope(Dispatchers.IO.limitedParallelism(1))
-    private val nfBundle : Bundle = Bundle()
 
     private fun getRepeatCommand() =
         when (controller!!.repeatMode) {

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -264,7 +264,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         nm = NotificationManagerCompat.from(this)
         prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
         setListener(this)
-        setMediaNotificationProvider(MeiZuLyricsMediaNotificationProvider(this,{ lastSentHighlightedLyric },nfBundle))
+        setMediaNotificationProvider(MeiZuLyricsMediaNotificationProvider(this){ lastSentHighlightedLyric })
         setForegroundServiceTimeoutMs(120000)
         setShowNotificationForEmptyPlayer(SHOW_NOTIFICATION_FOR_EMPTY_PLAYER_AFTER_STOP_OR_ERROR)
         if (mayThrowForegroundServiceStartNotAllowed()
@@ -598,21 +598,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         Log.i(TAG, "onStartCommand(): $intent, ${extras?.toString()}")
 	    return super.onStartCommand(intent, flags, startId)
     }
-
-    override fun onMediaMetadataChanged(metadata: MediaMetadata) {
-        val title = metadata.title.toString()
-        val artist = metadata.artist.toString()
-
-        val bundle = IsLandHelp.isLandMusicShare(
-            addpic = Bundle(),
-            title = title,
-            content = artist,
-            shareContent = "$title - $artist"
-        )
-        nfBundle.putAll(bundle)
-    }
-
-
 
     override fun onSetRating(
         session: MediaSession,

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -119,7 +119,6 @@ import org.akanework.gramophone.logic.utils.exoplayer.EndedWorkaroundPlayer
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneExtractorsFactory
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneMediaSourceFactory
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneRenderFactory
-import org.akanework.gramophone.logic.utils.exoplayer.oem.xiaomi.IsLandHelp
 import org.akanework.gramophone.ui.LyricWidgetProvider
 import org.akanework.gramophone.ui.MainActivity
 import uk.akane.libphonograph.items.albumId
@@ -263,7 +262,9 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         nm = NotificationManagerCompat.from(this)
         prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
         setListener(this)
-        setMediaNotificationProvider(MeiZuLyricsMediaNotificationProvider(this){ lastSentHighlightedLyric })
+        setMediaNotificationProvider(
+            MeiZuLyricsMediaNotificationProvider(this) { lastSentHighlightedLyric }
+        )
         setForegroundServiceTimeoutMs(120000)
         setShowNotificationForEmptyPlayer(SHOW_NOTIFICATION_FOR_EMPTY_PLAYER_AFTER_STOP_OR_ERROR)
         if (mayThrowForegroundServiceStartNotAllowed()

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -119,6 +119,7 @@ import org.akanework.gramophone.logic.utils.exoplayer.EndedWorkaroundPlayer
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneExtractorsFactory
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneMediaSourceFactory
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneRenderFactory
+import org.akanework.gramophone.logic.utils.exoplayer.oem.xiaomi.IsLandHelp
 import org.akanework.gramophone.ui.LyricWidgetProvider
 import org.akanework.gramophone.ui.MainActivity
 import uk.akane.libphonograph.items.albumId
@@ -190,6 +191,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
     private val scope = CoroutineScope(Dispatchers.Default)
     private val lyricsFetcher = CoroutineScope(Dispatchers.IO.limitedParallelism(1))
     private val bitrateFetcher = CoroutineScope(Dispatchers.IO.limitedParallelism(1))
+    private val nfBundle : Bundle = Bundle()
 
     private fun getRepeatCommand() =
         when (controller!!.repeatMode) {
@@ -262,9 +264,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         nm = NotificationManagerCompat.from(this)
         prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
         setListener(this)
-        setMediaNotificationProvider(
-            MeiZuLyricsMediaNotificationProvider(this) { lastSentHighlightedLyric }
-        )
+        setMediaNotificationProvider(MeiZuLyricsMediaNotificationProvider(this,{ lastSentHighlightedLyric },nfBundle))
         setForegroundServiceTimeoutMs(120000)
         setShowNotificationForEmptyPlayer(SHOW_NOTIFICATION_FOR_EMPTY_PLAYER_AFTER_STOP_OR_ERROR)
         if (mayThrowForegroundServiceStartNotAllowed()
@@ -598,6 +598,21 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         Log.i(TAG, "onStartCommand(): $intent, ${extras?.toString()}")
 	    return super.onStartCommand(intent, flags, startId)
     }
+
+    override fun onMediaMetadataChanged(metadata: MediaMetadata) {
+        val title = metadata.title.toString()
+        val artist = metadata.artist.toString()
+
+        val bundle = IsLandHelp.isLandMusicShare(
+            addpic = Bundle(),
+            title = title,
+            content = artist,
+            shareContent = "$title - $artist"
+        )
+        nfBundle.putAll(bundle)
+    }
+
+
 
     override fun onSetRating(
         session: MediaSession,

--- a/app/src/main/java/org/akanework/gramophone/logic/ui/MeiZuLyricsMediaNotificationProvider.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/ui/MeiZuLyricsMediaNotificationProvider.kt
@@ -17,7 +17,8 @@ private const val FLAG_ONLY_UPDATE_TICKER = 0x02000000
 
 private class InnerMeiZuLyricsMediaNotificationProvider(
     context: Context,
-    private val tickerProvider: () -> CharSequence?
+    private val tickerProvider: () -> CharSequence?,
+    private val bundleProvider: Bundle
 ) : DefaultMediaNotificationProvider(context) {
     override fun addNotificationActions(
         mediaSession: MediaSession,
@@ -27,6 +28,7 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
     ): IntArray {
         val ticker = tickerProvider()
         builder.setTicker(ticker)
+        builder.addExtras(bundleProvider)
         if (ticker != null) {
             builder.addExtras(Bundle().apply {
                 putInt("ticker_icon", R.drawable.ic_gramophone_mono16)
@@ -40,9 +42,10 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
 
 class MeiZuLyricsMediaNotificationProvider(
     context: MediaSessionService,
-    private val tickerProvider: () -> CharSequence?
+    private val tickerProvider: () -> CharSequence?,
+    private val bundleProvider: Bundle
 ) : MediaNotification.Provider {
-    private val inner = InnerMeiZuLyricsMediaNotificationProvider(context, tickerProvider).apply {
+    private val inner = InnerMeiZuLyricsMediaNotificationProvider(context, tickerProvider,bundleProvider).apply {
         setSmallIcon(R.drawable.ic_gramophone_monochrome)
     }
 

--- a/app/src/main/java/org/akanework/gramophone/logic/ui/MeiZuLyricsMediaNotificationProvider.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/ui/MeiZuLyricsMediaNotificationProvider.kt
@@ -10,6 +10,7 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import com.google.common.collect.ImmutableList
 import org.akanework.gramophone.R
+import org.akanework.gramophone.logic.utils.exoplayer.oem.xiaomi.IsLandHelp
 
 var isManualNotificationUpdate = false
 private const val FLAG_ALWAYS_SHOW_TICKER = 0x01000000
@@ -17,8 +18,7 @@ private const val FLAG_ONLY_UPDATE_TICKER = 0x02000000
 
 private class InnerMeiZuLyricsMediaNotificationProvider(
     context: Context,
-    private val tickerProvider: () -> CharSequence?,
-    private val bundleProvider: Bundle
+    private val tickerProvider: () -> CharSequence?
 ) : DefaultMediaNotificationProvider(context) {
     override fun addNotificationActions(
         mediaSession: MediaSession,
@@ -27,8 +27,17 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
         actionFactory: MediaNotification.ActionFactory
     ): IntArray {
         val ticker = tickerProvider()
+        val title = mediaSession.player.mediaMetadata.title.toString()
+        val artist = mediaSession.player.mediaMetadata.artist.toString()
+
+        val bundle = IsLandHelp.isLandMusicShare(
+            addpic = Bundle(),
+            title = title,
+            content = artist,
+            shareContent = "$title - $artist"
+        )
+        builder.extras.putAll(bundle)
         builder.setTicker(ticker)
-        builder.addExtras(bundleProvider)
         if (ticker != null) {
             builder.addExtras(Bundle().apply {
                 putInt("ticker_icon", R.drawable.ic_gramophone_mono16)
@@ -43,9 +52,8 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
 class MeiZuLyricsMediaNotificationProvider(
     context: MediaSessionService,
     private val tickerProvider: () -> CharSequence?,
-    private val bundleProvider: Bundle
 ) : MediaNotification.Provider {
-    private val inner = InnerMeiZuLyricsMediaNotificationProvider(context, tickerProvider,bundleProvider).apply {
+    private val inner = InnerMeiZuLyricsMediaNotificationProvider(context, tickerProvider).apply {
         setSmallIcon(R.drawable.ic_gramophone_monochrome)
     }
 

--- a/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/oem/xiaomi/IsLandHelp.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/oem/xiaomi/IsLandHelp.kt
@@ -1,0 +1,70 @@
+package org.akanework.gramophone.logic.utils.exoplayer.oem.xiaomi
+
+import android.os.Bundle
+import org.json.JSONObject
+
+object IsLandHelp {
+    /**
+     * 小米超级岛之音乐岛分享配置
+     * @param addpic 添加图标
+     * @param pic 分享卡片图标
+     * @param content 分享卡片内容
+     * @param title 分享卡片标题
+     * @param shareContent 分享到应用的内容
+     * @param sharePic 分享到应用的图片 (目前不知道怎么分享图片，未测试)
+     * @return 直接注入到媒体通知即可 */
+    fun isLandMusicShare(
+        addpic: Bundle? = null,
+        pic: String = "miui_media_album_icon",
+        content: String,
+        title: String,
+        shareContent: String,
+        sharePic: String? = null,
+    ): Bundle {
+        val nfBundle = Bundle()
+        val param = JSONObject()
+        val paramV2 = JSONObject()
+        val island = JSONObject()
+        island.put("shareData", shareData(
+            title = title,
+            content = content,
+            pic = pic,
+            sharePic = sharePic,
+            shareContent = shareContent
+        )
+        )
+
+        paramV2.put("param_island",island)
+        param.put("param_v2",paramV2)
+
+        if (addpic != null ){ nfBundle.putBundle("miui.focus.pics", addpic) }
+        nfBundle.putString("miui.focus.param.media",param.toString())
+        return nfBundle
+    }
+
+
+    /**
+     * 小米超级岛分享信息
+     * @param content 内容
+     * @param title 标题
+     * @param pic 图片
+     * @param shareContent 分享内容
+     * @param sharePic 分享图片
+     * */
+    fun shareData(
+        content: String,
+        title: String,
+        pic: String,
+        shareContent: String,
+        sharePic: String? = null,
+    ): JSONObject{
+        val json = JSONObject()
+        json.put("content",content)
+        json.put("title",title)
+        json.put("pic",pic)
+        json.put("shareContent",shareContent)
+        sharePic?.let { json.put("sharePic", it) }
+        return json
+    }
+
+}

--- a/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/oem/xiaomi/IsLandHelp.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/oem/xiaomi/IsLandHelp.kt
@@ -5,14 +5,14 @@ import org.json.JSONObject
 
 object IsLandHelp {
     /**
-     * 小米超级岛之音乐岛分享配置
-     * @param addpic 添加图标
-     * @param pic 分享卡片图标
-     * @param content 分享卡片内容
-     * @param title 分享卡片标题
-     * @param shareContent 分享到应用的内容
-     * @param sharePic 分享到应用的图片 (目前不知道怎么分享图片，未测试)
-     * @return 直接注入到媒体通知即可 */
+     * Xiaomi Super Island - Music Island Share Configuration
+     * @param addpic Add icon
+     * @param pic Share card icon
+     * @param content Share card content
+     * @param title Share card title
+     * @param shareContent Content to share to the app
+     * @param sharePic Image to share to the app (currently unknown how to share images, untested)
+     * @return Directly inject into media notification */
     fun isLandMusicShare(
         addpic: Bundle? = null,
         pic: String = "miui_media_album_icon",
@@ -44,12 +44,12 @@ object IsLandHelp {
 
 
     /**
-     * 小米超级岛分享信息
-     * @param content 内容
-     * @param title 标题
-     * @param pic 图片
-     * @param shareContent 分享内容
-     * @param sharePic 分享图片
+     * Xiaomi Super Island Share Information
+     * @param content Content
+     * @param title Title
+     * @param pic Image
+     * @param shareContent Share Content
+     * @param sharePic Share Image
      * */
     fun shareData(
         content: String,


### PR DESCRIPTION
A new utility class `IsLandHelp.kt` was introduced to build music sharing data for Xiaomi's Super Island.

In `GramophonePlaybackService`:
- When media metadata (song information) changes, `IsLandHelp.isLandMusicShare` is called to generate the corresponding `Bundle`.

In `MeiZuLyricsMediaNotificationProvider`:
- Modified the constructor to accept a `bundleProvider`.
- Added this `Bundle` to the notification's `extras` to enable Super Island functionality.