### PR TITLE
feat: Android Auto Media Browsing Support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,11 +69,11 @@
         <meta-data
             android:name="com.google.android.gms.car.application.theme"
             android:resource="@style/Theme.Gramophone"/>
-<!-- TODO uncomment to enable Android Auto when library browsing is implemented
+
         <meta-data
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc"/>
--->
+
         <activity
             android:name=".logic.ui.BugHandlerActivity"
             android:exported="false"
@@ -162,6 +162,13 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
+        <provider
+            android:name=".logic.GramophoneAlbumArtProvider"
+            android:authorities="org.akanework.gramophone.albumart"
+            android:exported="true"
+            android:grantUriPermissions="true" />
+
+
         <receiver android:name=".ui.LyricWidgetProvider"
             android:exported="false">
             <intent-filter>
@@ -225,6 +232,7 @@
         <!-- allow multi-resume for some Android 9 devices in multi-window -->
         <meta-data android:name="android.allow_multiple_resumed_activities" android:value="true" />
     </application>
+
 
     <queries>
         <intent>

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophoneAlbumArtProvider.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophoneAlbumArtProvider.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
+import android.util.Log
 import android.util.Size
 import uk.akane.libphonograph.Constants
 import uk.akane.libphonograph.utils.MiscUtils
@@ -18,6 +19,7 @@ import java.io.File
 import java.io.IOException
 
 class GramophoneAlbumArtProvider : ContentProvider() {
+    private val TAG = "GramophoneProvider"
 
     override fun onCreate() = true
 
@@ -70,6 +72,7 @@ class GramophoneAlbumArtProvider : ContentProvider() {
                 )
             } else null
         } catch (e: IOException) {
+            Log.d(TAG, "failed to generate song cover",e)
             null
         }
 
@@ -90,7 +93,8 @@ class GramophoneAlbumArtProvider : ContentProvider() {
                     input.copyTo(output)
                 }
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.d(TAG, "failed to generate song cover",e)
         }
     }
 
@@ -122,7 +126,8 @@ class GramophoneAlbumArtProvider : ContentProvider() {
                     input.copyTo(output)
                 }
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.d(TAG, "failed to generate album cover",e)
         }
     }
 

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophoneAlbumArtProvider.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophoneAlbumArtProvider.kt
@@ -1,0 +1,161 @@
+package org.akanework.gramophone.logic
+
+import android.content.ContentProvider
+import android.content.ContentUris
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
+import android.graphics.Bitmap
+import android.media.ThumbnailUtils
+import android.net.Uri
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import android.provider.MediaStore
+import android.util.Size
+import uk.akane.libphonograph.Constants
+import uk.akane.libphonograph.utils.MiscUtils
+import java.io.File
+import java.io.IOException
+
+class GramophoneAlbumArtProvider : ContentProvider() {
+
+    override fun onCreate() = true
+
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? {
+        val context = context ?: return null
+        val segments = uri.pathSegments
+
+        if (segments.size < 3) return null
+
+        val type = segments[0] // song or album
+        val id = segments[1]
+        val encodedPath = segments[2]
+        val realPath = Uri.decode(encodedPath)
+
+        val cacheFile = File(context.cacheDir, uri.toString().hashCode().toString())
+
+        if (!cacheFile.exists()) {
+            when (type) {
+                "song" -> {
+                    generateSongCover(context, realPath, id, cacheFile)
+                }
+                "album" -> {
+                    generateAlbumCover(context, realPath, id, cacheFile)
+                }
+            }
+        }
+
+        if (!cacheFile.exists()) return null
+
+        return ParcelFileDescriptor.open(
+            cacheFile,
+            ParcelFileDescriptor.MODE_READ_ONLY
+        )
+    }
+
+    private fun generateSongCover(
+        context: Context,
+        path: String,
+        id: String,
+        outFile: File
+    ) {
+        val file = File(path)
+
+        val bmp = try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ThumbnailUtils.createAudioThumbnail(
+                    file,
+                    Size(512, 512),
+                    null
+                )
+            } else null
+        } catch (e: IOException) {
+            null
+        }
+
+        if (bmp != null) {
+            saveBitmap(outFile, bmp)
+            return
+        }
+
+        // fallback MediaStore album art
+        val uri = ContentUris.withAppendedId(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            id.toLong()
+        ).buildUpon().appendPath("albumart").build()
+
+        try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                outFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun generateAlbumCover(
+        context: Context,
+        path: String,
+        id: String,
+        outFile: File
+    ) {
+        val cover = MiscUtils.findBestCover(File(path))
+
+        if (cover != null) {
+            cover.inputStream().use { input ->
+                outFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+            return
+        }
+
+        val uri = ContentUris.withAppendedId(
+            Constants.baseAlbumCoverUri,
+            id.toLong()
+        )
+
+        try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                outFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun saveBitmap(file: File, bmp: Bitmap) {
+        file.outputStream().use {
+            bmp.compress(Bitmap.CompressFormat.JPEG, 85, it)
+        }
+    }
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = "image/jpeg"
+
+    override fun insert(
+        uri: Uri,
+        values: ContentValues?
+    ): Uri? = null
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int = 0
+}

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -22,6 +22,7 @@ import android.app.PendingIntent
 import android.bluetooth.BluetoothCodecStatus
 import android.bluetooth.BluetoothProfile
 import android.content.BroadcastReceiver
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -74,6 +75,7 @@ import androidx.media3.exoplayer.util.EventLogger
 import androidx.media3.extractor.mp3.Mp3Extractor
 import androidx.media3.session.CacheBitmapLoader
 import androidx.media3.session.CommandButton
+import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaBrowser
 import androidx.media3.session.MediaConstants
 import androidx.media3.session.MediaLibraryService
@@ -113,6 +115,7 @@ import org.akanework.gramophone.logic.utils.LastPlayedManager
 import org.akanework.gramophone.logic.utils.LrcUtils.LrcParserOptions
 import org.akanework.gramophone.logic.utils.LrcUtils.extractAndParseLyrics
 import org.akanework.gramophone.logic.utils.LrcUtils.loadAndParseLyricsFile
+import org.akanework.gramophone.logic.utils.PlayerListHelp.dumpPlaylist
 import org.akanework.gramophone.logic.utils.ReplayGainAudioProcessor
 import org.akanework.gramophone.logic.utils.ReplayGainUtil
 import org.akanework.gramophone.logic.utils.SemanticLyrics
@@ -580,6 +583,101 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
             }
         }
         Log.i(TAG, "-onCreate()")
+    }
+
+    override fun onGetLibraryRoot(
+        session: MediaLibrarySession,
+        browser: MediaSession.ControllerInfo,
+        params: LibraryParams?
+    ): ListenableFuture<LibraryResult<MediaItem>> {
+        val rootItem = MediaItem.Builder()
+            .setMediaId("ROOT_ID")
+            .setMediaMetadata(MediaMetadata.Builder()
+                .setIsBrowsable(true)
+                .setIsPlayable(false)
+                .build())
+            .build()
+        return Futures.immediateFuture(LibraryResult.ofItem(rootItem, params))
+    }
+
+    // 在你的 MediaLibraryService.Callback 中
+    override fun onGetChildren(
+        session: MediaLibrarySession,
+        browser: MediaSession.ControllerInfo,
+        parentId: String,
+        page: Int,
+        pageSize: Int,
+        params: LibraryParams?
+    ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
+
+        return when (parentId) {
+            "ROOT_ID" -> {
+                val rootItems = mutableListOf<MediaItem>()
+                // 添加一个“当前播放队列”的文件夹
+                rootItems.add(createFolder("RECENT_QUEUE", "当前播放队列", R.drawable.ic_folder))
+                // ... 其他文件夹
+                Futures.immediateFuture(LibraryResult.ofItemList(rootItems, params))
+            }
+            else -> {
+                // 这里复用你 PlaylistCardAdapter 里的 dumpPlaylist() 逻辑
+                val playlistPair = dumpPlaylist(session.player)
+                // 解决类型不匹配：将 Pair 转换为 ImmutableList<MediaItem>
+                val orderedSongs: List<MediaItem> = playlistPair.first.map { index ->
+                    val originalItem = playlistPair.second[index]
+
+                    val contentArtUri = originalItem.mediaMetadata.artworkUri?.let { gramophoneSongCoverToContentUri(it) }
+
+                    originalItem.buildUpon()
+                        .setMediaMetadata(
+                            originalItem.mediaMetadata.buildUpon()
+                                .setArtworkUri(contentArtUri)
+                                .setIsBrowsable(false)
+                                .setIsPlayable(true)
+                                .build()
+                        )
+                        .build()
+                }
+
+                Futures.immediateFuture(LibraryResult.ofItemList(orderedSongs, params))
+            }
+        }
+    }
+
+    fun gramophoneSongCoverToContentUri(original: Uri): Uri {
+        require(original.scheme == "gramophoneSongCover") {
+            "只能转换 gramophoneSongCover:// URI"
+        }
+
+        val id = original.authority ?: "0"
+        val path = original.path ?: ""
+
+        return Uri.Builder()
+            .scheme(ContentResolver.SCHEME_CONTENT)
+            .authority("org.akanework.gramophone.albumart")
+            .appendPath("song")              // 类型 song / album
+            .appendPath(id)                  // albumId 或 songId
+            .appendPath(Uri.encode(path))    // 文件路径编码
+            .build()
+    }
+
+
+    private fun createFolder(
+        mediaId: String,
+        title: String,
+        iconResId: Int
+    ): MediaItem {
+        val metadata = MediaMetadata.Builder()
+            .setTitle(title)
+            .setIsBrowsable(true)  // 关键：设为 true，Android Auto 会将其显示为可点击进入的文件夹
+            .setIsPlayable(false)  // 文件夹通常不可直接播放（除非你想实现“点击文件夹即随机播放全部”）
+            // 将本地资源 ID 转换为 Uri，这样车机才能显示图标
+            .setArtworkUri(Uri.parse("android.resource://${packageName}/$iconResId"))
+            .build()
+
+        return MediaItem.Builder()
+            .setMediaId(mediaId)
+            .setMediaMetadata(metadata)
+            .build()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -600,6 +600,25 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         return Futures.immediateFuture(LibraryResult.ofItem(rootItem, params))
     }
 
+    override fun onGetItem(
+        session: MediaLibrarySession,
+        browser: MediaSession.ControllerInfo,
+        mediaId: String
+    ): ListenableFuture<LibraryResult<MediaItem>> {
+
+        val item = findMediaItemFromPlayer(session, mediaId)
+            ?: return Futures.immediateFuture(
+                LibraryResult.ofError(LibraryResult.RESULT_ERROR_BAD_VALUE)
+            )
+
+        val fixed = item.fixArtworkForAuto()
+
+        return Futures.immediateFuture(
+            LibraryResult.ofItem(fixed, null)
+        )
+    }
+
+
     // 在你的 MediaLibraryService.Callback 中
     override fun onGetChildren(
         session: MediaLibrarySession,
@@ -619,26 +638,47 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
                 Futures.immediateFuture(LibraryResult.ofItemList(rootItems, params))
             }
             else -> {
-                // 这里复用你 PlaylistCardAdapter 里的 dumpPlaylist() 逻辑
-                val playlistPair = dumpPlaylist(session.player)
-                // 解决类型不匹配：将 Pair 转换为 ImmutableList<MediaItem>
-                val orderedSongs: List<MediaItem> = playlistPair.first.map { index ->
-                    val originalItem = playlistPair.second[index]
+                val future = SettableFuture.create<LibraryResult<ImmutableList<MediaItem>>>()
 
-                    val contentArtUri = originalItem.mediaMetadata.artworkUri?.let { gramophoneSongCoverToContentUri(it) }
+                lifecycleScope.launch(Dispatchers.Default) {
 
-                    originalItem.buildUpon()
-                        .setMediaMetadata(
-                            originalItem.mediaMetadata.buildUpon()
-                                .setArtworkUri(contentArtUri)
-                                .setIsBrowsable(false)
-                                .setIsPlayable(true)
+                    try {
+                        val songList = gramophoneApplication.reader.songListFlow.first()
+
+                        val orderedSongs: List<MediaItem> = songList.map { item ->
+
+                            val contentArtUri = item.mediaMetadata.artworkUri?.let {
+                                if (it.scheme == "gramophoneSongCover")
+                                    gramophoneSongCoverToContentUri(it)
+                                else
+                                    it
+                            }
+
+                            item.buildUpon()
+                                .setMediaMetadata(
+                                    item.mediaMetadata.buildUpon()
+                                        .setArtworkUri(contentArtUri)
+                                        .setIsBrowsable(false)
+                                        .setIsPlayable(true)
+                                        .build()
+                                )
                                 .build()
+                        }
+
+                        future.set(
+                            LibraryResult.ofItemList(
+                                ImmutableList.copyOf(orderedSongs),
+                                params
+                            )
                         )
-                        .build()
+
+                    } catch (e: Exception) {
+                        future.setException(e)
+                    }
                 }
 
-                Futures.immediateFuture(LibraryResult.ofItemList(orderedSongs, params))
+                future
+
             }
         }
     }
@@ -660,6 +700,24 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
             .build()
     }
 
+    private fun findMediaItemFromPlayer(
+        session: MediaLibrarySession,
+        mediaId: String
+    ): MediaItem? {
+
+        val player = session.player
+
+        for (i in 0 until player.mediaItemCount) {
+            val item = player.getMediaItemAt(i)
+            if (item.mediaId == mediaId) {
+                return item
+            }
+        }
+
+        return null
+    }
+
+
 
     private fun createFolder(
         mediaId: String,
@@ -679,6 +737,28 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
             .setMediaMetadata(metadata)
             .build()
     }
+
+    private fun MediaItem.fixArtworkForAuto(): MediaItem {
+        val art = mediaMetadata.artworkUri
+
+        if (art == null) return this
+
+        val newArt = if (art.scheme == "gramophoneSongCover") {
+            gramophoneSongCoverToContentUri(art)
+        } else {
+            art
+        }
+        Log.d(TAG, "fixArtworkForAuto: $newArt")
+
+        return buildUpon()
+            .setMediaMetadata(
+                mediaMetadata.buildUpon()
+                    .setArtworkUri(newArt)
+                    .build()
+            )
+            .build()
+    }
+
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         var extras = intent?.extras
@@ -1305,19 +1385,27 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         controller: MediaSession.ControllerInfo,
         mediaItems: List<MediaItem>
     ): ListenableFuture<List<MediaItem>> {
-        if (mediaItems.find { it.localConfiguration == null } == null) // fast path
+        if (mediaItems.all { item ->
+                item.localConfiguration != null &&
+                        (
+                                item.mediaMetadata.artworkUri == null ||
+                                        item.mediaMetadata.artworkUri?.scheme != "gramophoneSongCover"
+                                )
+            }) {
             return Futures.immediateFuture(mediaItems)
+        } // fast path
+
         val completion = SettableFuture.create<List<MediaItem>>()
         lifecycleScope.launch(Dispatchers.Default) {
             try {
                 val result = mediaItems.flatMap {
                     if (it.localConfiguration != null)
-                        listOf(it)
+                        listOf(it.fixArtworkForAuto())
                     else if (it.mediaId != MediaItem.DEFAULT_MEDIA_ID)
                         gramophoneApplication.reader.songListFlow.first()
                             .filter { m -> m.mediaId == it.mediaId }
                     else if (it.requestMetadata.searchQuery != null)
-                        searchForMediaItem(it)
+                        searchForMediaItem(it.fixArtworkForAuto())
                     else
                         throw UnsupportedOperationException("can't do anything with $it")
                 }

--- a/app/src/main/java/org/akanework/gramophone/logic/utils/PlayerListHelp.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/PlayerListHelp.kt
@@ -1,0 +1,24 @@
+package org.akanework.gramophone.logic.utils
+
+import android.os.SystemClock
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import java.util.LinkedList
+
+object PlayerListHelp {
+    fun dumpPlaylist(instance: Player): Pair<MutableList<Int>, MutableList<MediaItem>> {
+        val items = LinkedList<MediaItem>()
+        for (i in 0 until instance.mediaItemCount) {
+            items.add(instance.getMediaItemAt(i))
+        }
+        val indexes = LinkedList<Int>()
+        val s = instance.shuffleModeEnabled
+        var i = instance.currentTimeline.getFirstWindowIndex(s)
+        while (i != C.INDEX_UNSET) {
+            indexes.add(i)
+            i = instance.currentTimeline.getNextWindowIndex(i, Player.REPEAT_MODE_OFF, s)
+        }
+        return Pair(indexes, items)
+    }
+}

--- a/app/src/main/java/org/akanework/gramophone/ui/components/PlaylistQueueSheet.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/components/PlaylistQueueSheet.kt
@@ -19,6 +19,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import org.akanework.gramophone.R
 import org.akanework.gramophone.logic.replaceAllSupport
 import org.akanework.gramophone.logic.ui.MyRecyclerView
+import org.akanework.gramophone.logic.utils.PlayerListHelp.dumpPlaylist
 import org.akanework.gramophone.logic.utils.convertDurationToTimeStamp
 import org.akanework.gramophone.ui.MainActivity
 import java.util.LinkedList
@@ -114,7 +115,7 @@ class PlaylistQueueSheet(
     }
 
     private inner class PlaylistCardAdapter : EditSongAdapter(activity) {
-        var playlist: Pair<MutableList<Int>, MutableList<MediaItem>> = dumpPlaylist()
+        var playlist: Pair<MutableList<Int>, MutableList<MediaItem>> = dumpPlaylist(activity.getPlayer()!!)
 
         init {
             updateList()
@@ -218,22 +219,6 @@ class PlaylistQueueSheet(
         override fun getItem(pos: Int) = playlist.second[playlist.first[pos]]
         override fun startDrag(holder: ViewHolder) {
             touchHelper.startDrag(holder)
-        }
-
-        private fun dumpPlaylist(): Pair<MutableList<Int>, MutableList<MediaItem>> {
-            val items = LinkedList<MediaItem>()
-            val instance = activity.getPlayer()!!
-            for (i in 0 until instance.mediaItemCount) {
-                items.add(instance.getMediaItemAt(i))
-            }
-            val indexes = LinkedList<Int>()
-            val s = instance.shuffleModeEnabled
-            var i = instance.currentTimeline.getFirstWindowIndex(s)
-            while (i != C.INDEX_UNSET) {
-                indexes.add(i)
-                i = instance.currentTimeline.getNextWindowIndex(i, Player.REPEAT_MODE_OFF, s)
-            }
-            return Pair(indexes, items)
         }
 
         private fun updateList() {


### PR DESCRIPTION
Adds media browsing functionality to Android Auto.

Key changes include:
- Implemented `onGetLibraryRoot` and `onGetChildren` in `GramophonePlaybackService` to provide the media library browsing structure, currently supporting only the “current playback queue”.
- Added `GramophoneAlbumArtProvider` to supply album art to Android Auto via `ContentProvider`, resolving cover art display issues on Android Auto.
- Refactored `dumpPlaylist` logic and migrated it to the new `PlayerListHelp` utility class for reuse between `Service` and `UI`.
- Registered `GramophoneAlbumArtProvider` in `AndroidManifest.xml` and officially enabled Android Auto functionality.

Translated with DeepL.com (free version)