### PR TITLE
Migrate build configuration to Gradle Version Catalogs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,18 +5,15 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.util.removeSuffixIfPresent
 import java.util.Properties
 
-val aboutLibsVersion = "13.1.0" // keep in sync with plugin version
-val kotlinVersion = "2.3.0"
-
 plugins {
-    id("com.android.application")
-    id("com.android.built-in-kotlin")
-    id("androidx.baselineprofile")
-    kotlin("plugin.parcelize")
-    kotlin("plugin.compose")
-    id("com.mikepenz.aboutlibraries.plugin")
-    id("com.mikepenz.aboutlibraries.plugin.android")
-    id("pt.jcosta.resourceplaceholders")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.android.builtin.kotlin)
+    alias(libs.plugins.baselineprofile)
+    alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.aboutlibraries)
+    alias(libs.plugins.aboutlibraries.android)
+    alias(libs.plugins.resourceplaceholders)
 }
 
 android {
@@ -272,48 +269,46 @@ aboutLibraries {
 dependencies {
     implementation(project(":hificore"))
     implementation(project(":misc:alacdecoder"))
-    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-    implementation("androidx.compose.material:material-icons-extended")
-    implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.material3.adaptive:adaptive")
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    debugImplementation("androidx.compose.ui:ui-tooling")
-    implementation("androidx.activity:activity-compose:1.11.0")
-    implementation("androidx.appcompat:appcompat:1.7.1")
-    implementation("androidx.collection:collection-ktx:1.5.0")
-    implementation("androidx.concurrent:concurrent-futures-ktx:1.3.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    implementation("androidx.core:core-ktx:1.17.0")
-    implementation("androidx.core:core-splashscreen:1.2.0")
-    implementation("androidx.fragment:fragment-ktx:1.8.9")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.4")
-    implementation("androidx.mediarouter:mediarouter:1.8.1")
-    val media3Version = "1.9.1"
-    implementation("androidx.media3:media3-common-ktx:$media3Version")
-    implementation("androidx.media3:media3-exoplayer:$media3Version")
-    implementation("androidx.media3:media3-exoplayer-midi:$media3Version")
-    implementation("androidx.media3:media3-session:$media3Version")
+    implementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material3.adaptive)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.collection.ktx)
+    implementation(libs.androidx.concurrent.futures.ktx)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
+    implementation(libs.androidx.fragment.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.mediarouter)
+    implementation(libs.androidx.media3.common.ktx)
+    implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.androidx.media3.exoplayer.midi)
+    implementation(libs.androidx.media3.session)
     //implementation("androidx.paging:paging-runtime-ktx:3.2.1") TODO paged, partial, flow based library loading
     //implementation("androidx.paging:paging-guava:3.2.1") TODO do we have guava? do we need this?
-    implementation("androidx.preference:preference-ktx:1.2.1")
-    implementation("androidx.transition:transition-ktx:1.6.0") // <-- for predictive back TODO can we remove explicit dep now?
-    implementation("com.mikepenz:aboutlibraries-compose-m3:$aboutLibsVersion")
-    implementation("com.google.android.material:material:1.13.0")
-    implementation("me.zhanghai.android.fastscroll:library:1.3.0")
-    implementation("io.coil-kt.coil3:coil-compose:3.3.0")
-    implementation("org.lsposed.hiddenapibypass:hiddenapibypass:6.1")
+    implementation(libs.androidx.preference.ktx)
+    implementation(libs.androidx.transition.ktx) // <-- for predictive back TODO can we remove explicit dep now?
+    implementation(libs.aboutlibraries.compose.m3)
+    implementation(libs.material)
+    implementation(libs.fastscroll)
+    implementation(libs.coil.compose)
+    implementation(libs.hiddenapibypass)
     //noinspection GradleDependency newer versions need java.nio which is api 26+
     //implementation("com.github.albfernandez:juniversalchardet:2.0.3") TODO
-    implementation("androidx.profileinstaller:profileinstaller:1.4.1")
+    implementation(libs.androidx.profileinstaller)
     "baselineProfile"(project(":baselineprofile"))
     // --- below does not apply to release builds ---
-    debugImplementation("com.squareup.leakcanary:leakcanary-android:2.14")
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.16.1")
-    "userdebugImplementation"(kotlin("reflect", kotlinVersion)) // who thought String.invoke() is a good idea?????
-    debugImplementation(kotlin("reflect", kotlinVersion))
+    debugImplementation(libs.leakcanary.android)
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
+    "userdebugImplementation"(libs.kotlin.reflect) // who thought String.invoke() is a good idea?????
+    debugImplementation(libs.kotlin.reflect)
 }
 
 fun String.runCommand(

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -4,9 +4,9 @@ import com.android.build.api.dsl.ManagedVirtualDevice
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-	id("com.android.test")
-    id("com.android.built-in-kotlin")
-	id("androidx.baselineprofile")
+	alias(libs.plugins.android.test)
+    alias(libs.plugins.android.builtin.kotlin)
+	alias(libs.plugins.baselineprofile)
 }
 
 android {
@@ -58,10 +58,10 @@ baselineProfile {
 }
 
 dependencies {
-	implementation("androidx.test.ext:junit:1.3.0")
-	implementation("androidx.test.espresso:espresso-core:3.7.0")
-	implementation("androidx.test.uiautomator:uiautomator:2.3.0")
-	implementation("androidx.benchmark:benchmark-macro-junit4:1.4.1")
+	implementation(libs.androidx.test.ext.junit)
+	implementation(libs.androidx.test.espresso.core)
+	implementation(libs.androidx.test.uiautomator)
+	implementation(libs.androidx.benchmark.macro.junit4)
 }
 
 androidComponents {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    val agpVersion = "9.0.1"
-    id("com.android.application") version agpVersion apply false
-    id("com.android.built-in-kotlin") version agpVersion apply false
-	id("com.android.library") version agpVersion apply false
-	id("com.android.test") version agpVersion apply false
-	id("androidx.baselineprofile") version "1.5.0-alpha03" apply false
-    val kotlinVersion = "2.3.0"
-	kotlin("android") version kotlinVersion apply false
-    kotlin("plugin.parcelize") version kotlinVersion apply false
-    kotlin("plugin.compose") version kotlinVersion apply false
-    val aboutLibsVersion = "14.0.0-b02"
-    id("com.mikepenz.aboutlibraries.plugin") version aboutLibsVersion apply false
-    id("com.mikepenz.aboutlibraries.plugin.android") version aboutLibsVersion apply false
-    id("com.osacky.doctor") version "0.12.1"
-    id("pt.jcosta.resourceplaceholders") version "0.11.2" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.builtin.kotlin) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.android.test) apply false
+    alias(libs.plugins.baselineprofile) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.aboutlibraries) apply false
+    alias(libs.plugins.aboutlibraries.android) apply false
+    alias(libs.plugins.doctor)
+    alias(libs.plugins.resourceplaceholders) apply false
 }
 
 doctor {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,94 @@
+[versions]
+agp = "9.0.1"
+kotlin = "2.3.0"
+baselineprofile = "1.5.0-alpha03"
+aboutlibraries = "13.1.0"
+aboutlibraries-plugin = "14.0.0-b02"
+doctor = "0.12.1"
+resourceplaceholders = "0.11.2"
+
+compose-bom = "2025.05.00"
+activity-compose = "1.11.0"
+appcompat = "1.7.1"
+collection-ktx = "1.5.0"
+concurrent-futures-ktx = "1.3.0"
+constraintlayout = "2.2.1"
+core-ktx = "1.17.0"
+core-splashscreen = "1.2.0"
+fragment-ktx = "1.8.9"
+lifecycle = "2.9.4"
+mediarouter = "1.8.1"
+media3 = "1.9.1"
+preference-ktx = "1.2.1"
+transition-ktx = "1.6.0"
+material = "1.13.0"
+fastscroll = "1.3.0"
+coil = "3.3.0"
+hiddenapibypass = "6.1"
+profileinstaller = "1.4.1"
+leakcanary = "2.14"
+junit = "4.13.2"
+robolectric = "4.16.1"
+dlfunc = "0.1.6"
+androidx-test-ext-junit = "1.3.0"
+espresso-core = "3.7.0"
+uiautomator = "2.3.0"
+benchmark-macro-junit4 = "1.4.1"
+annotation = "1.9.1"
+
+[libraries]
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-collection-ktx = { group = "androidx.collection", name = "collection-ktx", version.ref = "collection-ktx" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material3-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-concurrent-futures-ktx = { group = "androidx.concurrent", name = "concurrent-futures-ktx", version.ref = "concurrent-futures-ktx" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "core-splashscreen" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment-ktx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+androidx-media3-common = { group = "androidx.media3", name = "media3-common", version.ref = "media3" }
+androidx-media3-common-ktx = { group = "androidx.media3", name = "media3-common-ktx", version.ref = "media3" }
+androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+androidx-media3-exoplayer-midi = { group = "androidx.media3", name = "media3-exoplayer-midi", version.ref = "media3" }
+androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3" }
+androidx-mediarouter = { group = "androidx.mediarouter", name = "mediarouter", version.ref = "mediarouter" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference-ktx" }
+androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
+androidx-transition-ktx = { group = "androidx.transition", name = "transition-ktx", version.ref = "transition-ktx" }
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "annotation" }
+
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
+androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
+androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmark-macro-junit4" }
+
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+aboutlibraries-compose-m3 = { group = "com.mikepenz", name = "aboutlibraries-compose-m3", version.ref = "aboutlibraries" }
+fastscroll = { group = "me.zhanghai.android.fastscroll", name = "library", version.ref = "fastscroll" }
+hiddenapibypass = { group = "org.lsposed.hiddenapibypass", name = "hiddenapibypass", version.ref = "hiddenapibypass" }
+leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+dlfunc = { group = "io.github.nift4.dlfunc", name = "dlfunc", version.ref = "dlfunc" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+android-test = { id = "com.android.test", version.ref = "agp" }
+android-builtin-kotlin = { id = "com.android.built-in-kotlin", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
+aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries-plugin" }
+aboutlibraries-android = { id = "com.mikepenz.aboutlibraries.plugin.android", version.ref = "aboutlibraries-plugin" }
+doctor = { id = "com.osacky.doctor", version.ref = "doctor" }
+resourceplaceholders = { id = "pt.jcosta.resourceplaceholders", version.ref = "resourceplaceholders" }

--- a/hificore/build.gradle.kts
+++ b/hificore/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("com.android.library")
-    id("com.android.built-in-kotlin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.android.builtin.kotlin)
 }
 
 android {
@@ -59,9 +59,9 @@ kotlin {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.17.0")
-    implementation("androidx.media3:media3-common:1.9.0")
-    implementation("io.github.nift4.dlfunc:dlfunc:0.1.6")
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.media3.common)
+    implementation(libs.dlfunc)
     implementation(project(":misc:audiofxfwd"))
     // stub project that provides hidden SDK classes, which themselves depend on public SDK
     compileOnly(project(":misc:audiofxstub2"))

--- a/misc/alacdecoder/build.gradle.kts
+++ b/misc/alacdecoder/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 
 android {
@@ -34,6 +34,6 @@ android {
 }
 
 dependencies {
-    implementation("androidx.annotation:annotation:1.9.1")
-    implementation("androidx.media3:media3-exoplayer")
+    implementation(libs.androidx.annotation)
+    implementation(libs.androidx.media3.exoplayer)
 }

--- a/misc/audiofxstub2/build.gradle.kts
+++ b/misc/audiofxstub2/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 
 android {


### PR DESCRIPTION
This PR migrates the built do use Version Catalogs for easier library management.

No actual versions were changed, they have all been kept the same as before. 