### PR TITLE
feat: locale-aware queue titles via QueueTitle sealed class

### DIFF
--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -126,6 +126,7 @@ import org.akanework.gramophone.logic.utils.ReplayGainUtil
 import org.akanework.gramophone.logic.utils.SemanticLyrics
 import org.akanework.gramophone.logic.utils.exoplayer.EndedWorkaroundPlayer
 import org.akanework.gramophone.logic.utils.exoplayer.EndedWorkaroundPlayer.Companion.queueWithTitle
+import org.akanework.gramophone.logic.QueueTitle
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneExtractorsFactory
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneMediaSourceFactory
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneRenderFactory
@@ -566,7 +567,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
                     val list = runBlocking { mapMediaItemsForFavorites(items.mediaItems) }
                     try {
                         mediaSession?.player?.setMediaItems(
-                            queueWithTitle(list, "lastPlayedManager"),
+                            queueWithTitle(list, QueueTitle.Custom("lastPlayedManager")),
                             items.startIndex,
                             items.startPositionMs
                         )

--- a/app/src/main/java/org/akanework/gramophone/logic/QueueBoard.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/QueueBoard.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import android.os.Parcelable
 import android.util.Log
+import androidx.annotation.StringRes
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.fastSumBy
 import androidx.media3.common.C
@@ -12,6 +13,53 @@ import androidx.media3.common.Player
 import androidx.media3.common.Player.REPEAT_MODE_OFF
 import org.akanework.gramophone.logic.utils.CircularShuffleOrder
 import kotlin.random.Random
+
+/**
+ * Represents a queue title that may be backed by a string resource (localizable) or a
+ * user-defined custom string (not localizable).
+ *
+ * Use [QueueTitle.Resource] for system-generated titles (e.g. "Songs", "Albums") so they are
+ * resolved from the current locale at display time rather than baked in at play time.
+ * Use [QueueTitle.Custom] for user-defined names such as playlist titles.
+ */
+sealed class QueueTitle {
+    /** A title backed by an Android string resource. Resolved at display time via [resolve]. */
+    data class Resource(@StringRes val resId: Int) : QueueTitle()
+
+    /** A title provided directly as a user-defined string. */
+    data class Custom(val name: String) : QueueTitle()
+
+    /** Resolve this title to a display string using the provided [context]. */
+    fun resolve(context: Context): String = when (this) {
+        is Resource -> context.getString(resId)
+        is Custom -> name
+    }
+
+    fun toBundle(): Bundle = Bundle().apply {
+        when (val t = this@QueueTitle) {
+            is Resource -> {
+                putString("type", "resource")
+                putInt("resId", t.resId)
+            }
+            is Custom -> {
+                putString("type", "custom")
+                putString("name", t.name)
+            }
+        }
+    }
+
+    companion object {
+        fun fromBundle(bundle: Bundle): QueueTitle {
+            return when (bundle.getString("type")) {
+                "resource" -> Resource(bundle.getInt("resId"))
+                else -> Custom(bundle.getString("name") ?: "")
+            }
+        }
+
+        /** Deserialize from the legacy plain-string format used before this change. */
+        fun fromLegacyString(title: String): QueueTitle = Custom(title)
+    }
+}
 
 private const val QUEUE_EXPIRY_MS = 10 * 36000000 // 10 hrs
 
@@ -141,7 +189,7 @@ class QueueBoard(
      *
      */
     fun addQueue(
-        title: String,
+        title: QueueTitle,
         mediaList: List<MediaItem>,
         mediaItemIndex: Int = 0,
         startPositionMs: Long?,
@@ -156,8 +204,9 @@ class QueueBoard(
                         "replace/startIndex = $isOriginal/$mediaItemIndex"
             )
 
-        // look for matching queue. Title is (effectively) uid
-        val match = masterQueues.firstOrNull { it.title.trimEnd() == title }
+        // look for matching queue. Title is (effectively) uid; compare resolved strings
+        val titleKey = title.resolve(context)
+        val match = masterQueues.firstOrNull { it.title.resolve(context).trimEnd() == titleKey }
 
         if (match != null) {
             val containsAll =
@@ -184,8 +233,9 @@ class QueueBoard(
 
                 // Titles ending in "+​" aka \u200B signify a extension queue
                 // Original copies will transion into an extention queue when media items are added
-                if (!match.title.endsWith("(+\u200B)")) {
-                    match.title = match.title + "(+\u200B)"
+                val resolvedName = match.title.resolve(context)
+                if (!resolvedName.endsWith("(+\u200B)")) {
+                    match.title = QueueTitle.Custom(resolvedName + "(+\u200B)")
                 }
             }
 
@@ -228,7 +278,7 @@ class QueueBoard(
         if (QUEUE_DEBUG)
             Log.d(TAG, "DELETING QUEUE ${mq.title}")
 
-        val match = masterQueues.firstOrNull { it.title == mq.title }
+        val match = masterQueues.firstOrNull { it.title == mq.title || it.title.resolve(context) == mq.title.resolve(context) }
         if (match != null) {
             masterQueues.remove(match)
         } else {
@@ -335,7 +385,7 @@ class QueueBoard(
 
 
     fun renameQueue(mq: MultiQueueObject, newName: String): Boolean {
-        if (masterQueues.any { it.title == newName }) {
+        if (masterQueues.any { it.title.resolve(context) == newName }) {
             if (QUEUE_DEBUG)
                 Log.d(TAG, "Failed to rename queue to \"$newName\". Already exists")
             return false
@@ -344,7 +394,7 @@ class QueueBoard(
         if (found) {
             val oldIndex = masterQueues.indexOf(mq)
             val q = masterQueues.removeAt(oldIndex)
-            masterQueues.add(oldIndex, q.copy(title = newName))
+            masterQueues.add(oldIndex, q.copy(title = QueueTitle.Custom(newName)))
 
             if (QUEUE_DEBUG)
                 Log.d(TAG, "Successfully renamed queue from \"${mq.title}\" to \"$newName\"")
@@ -522,7 +572,7 @@ private fun MutableList<MultiQueueObject>.bubbleUp(mq: MultiQueueObject) {
 data class MultiQueueObject(
     val id: Long, // queue uid
     var index: Int, // order of queue
-    var title: String,
+    var title: QueueTitle,
     var expiry: Long?,
     /**
      * The order of songs are dynamic. This should not be accessed from outside QueueBoard.
@@ -592,7 +642,7 @@ data class MultiQueueObject(
 
             putLong("id", id)
             putInt("index", index)
-            putString("title", title)
+            putBundle("title", title.toBundle())
             putString("expiry", expiry?.toString())
 
 //            putBinder("queue", binder)
@@ -622,7 +672,8 @@ data class MultiQueueObject(
             return MultiQueueObject(
                 id = bundle.getLong("id"),
                 index = bundle.getInt("index"),
-                title = bundle.getString("title") ?: "",
+                title = bundle.getBundle("title")?.let { QueueTitle.fromBundle(it) }
+                    ?: QueueTitle.fromLegacyString(bundle.getString("title") ?: ""),
                 expiry = bundle.getString("expiry")?.toLongOrNull(),
 //                queue = queue,
                 queue = (bundle.getParcelableArrayList<Bundle>("queue")

--- a/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
@@ -13,6 +13,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import org.akanework.gramophone.BuildConfig
 import org.akanework.gramophone.R
 import org.akanework.gramophone.logic.QueueBoard
+import org.akanework.gramophone.logic.QueueTitle
 import org.akanework.gramophone.logic.utils.CircularShuffleOrder
 import org.akanework.gramophone.logic.utils.SemanticLyrics
 import org.json.JSONObject
@@ -34,13 +35,13 @@ class EndedWorkaroundPlayer(
     companion object {
         private const val TAG = "EndedWorkaroundPlayer"
 
-        fun queueWithTitle(mediaItems: List<MediaItem>, mqTitle: String?): List<MediaItem> {
+        fun queueWithTitle(mediaItems: List<MediaItem>, mqTitle: QueueTitle?): List<MediaItem> {
             if (mediaItems.isEmpty() || mqTitle == null) return mediaItems
             val firstMediaItem = mediaItems.first()
             val newFirstMediaItem = firstMediaItem.buildUpon().setMediaMetadata(
                 firstMediaItem.mediaMetadata.buildUpon().setExtras(
                     (firstMediaItem.mediaMetadata.extras?.let { Bundle(it) } ?: Bundle()).apply {
-                        putString("mq_title", mqTitle)
+                        putBundle("mq_title_bundle", mqTitle.toBundle())
                     }
                 ).build()
             ).build()
@@ -142,9 +143,10 @@ class EndedWorkaroundPlayer(
         startIndex: Int,
         startPositionMs: Long
     ): ListenableFuture<*> {
-        val defaultQueueTitle = queueBoard.context.getString(R.string.unknown_playlist)
+        val defaultQueueTitle = QueueTitle.Resource(R.string.unknown_playlist)
         val firstMediaItem = mediaItems.firstOrNull()
-        val mqTitle = firstMediaItem?.mediaMetadata?.extras?.getString("mq_title")
+        val mqTitle = firstMediaItem?.mediaMetadata?.extras?.getBundle("mq_title_bundle")
+            ?.let { QueueTitle.fromBundle(it) }
 
         val mq = queueBoard.addQueue(
             title = mqTitle ?: defaultQueueTitle,

--- a/app/src/main/java/org/akanework/gramophone/ui/adapters/AlbumAdapter.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/adapters/AlbumAdapter.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.akanework.gramophone.R
+import org.akanework.gramophone.logic.QueueTitle
 import org.akanework.gramophone.logic.getFile
 import org.akanework.gramophone.logic.requireMediaStoreId
 import org.akanework.gramophone.ui.MainActivity
@@ -38,7 +39,7 @@ import java.util.GregorianCalendar
 
 class AlbumAdapter(
     fragment: Fragment,
-    val queueTitle: Flow<String>,
+    val queueTitle: Flow<QueueTitle>,
     liveData: Flow<List<Album>?> = (fragment.requireActivity() as MainActivity).reader.albumListFlow,
     isSubFragment: Int? = null
 ) : BaseAdapter<Album>

--- a/app/src/main/java/org/akanework/gramophone/ui/adapters/SongAdapter.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/adapters/SongAdapter.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.akanework.gramophone.R
+import org.akanework.gramophone.logic.QueueTitle
 import org.akanework.gramophone.logic.getBooleanStrict
 import org.akanework.gramophone.logic.getFile
 import org.akanework.gramophone.logic.gramophoneApplication
@@ -70,7 +71,7 @@ import java.util.GregorianCalendar
  */
 class SongAdapter(
     fragment: Fragment?,
-    val queueTitle: Flow<String>,
+    val queueTitle: Flow<QueueTitle>,
     songList: Flow<List<MediaItem>?> = (fragment?.requireContext() ?: fallbackContext!!)
         .gramophoneApplication.reader.songListFlow,
     helper: Sorter.NaturalOrderHelper<MediaItem>? = null,

--- a/app/src/main/java/org/akanework/gramophone/ui/fragments/AdapterFragment.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/fragments/AdapterFragment.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOf
 import me.zhanghai.android.fastscroll.PopupTextProvider
 import org.akanework.gramophone.R
+import org.akanework.gramophone.logic.QueueTitle
 import org.akanework.gramophone.logic.enableEdgeToEdgePaddingListener
 import org.akanework.gramophone.logic.ui.ItemHeightHelper
 import org.akanework.gramophone.logic.ui.MyRecyclerView
@@ -130,7 +131,7 @@ class AdapterFragment : BaseFragment(null) {
         }
     }
 
-    fun getQueueTitle(): Flow<String> {
+    fun getQueueTitle(): Flow<QueueTitle> {
         val stringId = when (arguments?.getInt("ID", -1)) {
             R.id.songs -> R.string.category_songs
             R.id.albums -> R.string.category_albums
@@ -142,8 +143,8 @@ class AdapterFragment : BaseFragment(null) {
             R.id.playlists -> R.string.category_playlists
             else -> null
         }
-        if (stringId == null) return flowOf("MISSING TITLE (AdapterFragment)")
-        return flowOf(requireContext().getString( stringId))
+        if (stringId == null) return flowOf(QueueTitle.Custom("MISSING TITLE (AdapterFragment)"))
+        return flowOf(QueueTitle.Resource(stringId))
     }
 
     abstract class BaseInterface<T : RecyclerView.ViewHolder>

--- a/app/src/main/java/org/akanework/gramophone/ui/fragments/GeneralSubFragment.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/fragments/GeneralSubFragment.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.akanework.gramophone.R
+import org.akanework.gramophone.logic.QueueTitle
 import org.akanework.gramophone.logic.enableEdgeToEdgePaddingListener
 import org.akanework.gramophone.logic.ui.MyRecyclerView
 import org.akanework.gramophone.logic.utils.flows.PauseManagingSharedFlow.Companion.sharePauseableIn
@@ -53,7 +54,7 @@ import uk.akane.libphonograph.items.Playlist
  * @author AkaneTan, nift4
  */
 class GeneralSubFragment : BaseFragment(true) {
-    lateinit var qTitle: Flow<String>
+    lateinit var qTitle: Flow<QueueTitle>
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -82,7 +83,7 @@ class GeneralSubFragment : BaseFragment(true) {
             R.id.album -> {
                 val item = mainActivity.reader.albumListFlow.map { it.find { it.id == id } }
                 title = item.map { it?.title ?: requireContext().getString(R.string.unknown_album) }
-                qTitle = title
+                qTitle = title.map { QueueTitle.Custom(it) }
                 itemList = item.map { it?.songList }
                 rawOrderExposed = Sorter.Type.ByAlbumTitleAscending
             }
@@ -97,7 +98,7 @@ class GeneralSubFragment : BaseFragment(true) {
                 // Genres
                 val item = mainActivity.reader.genreListFlow.map { it.find { it.id == id } }
                 title = item.map { it?.title ?: requireContext().getString(R.string.unknown_genre) }
-                qTitle = title
+                qTitle = title.map { QueueTitle.Custom(it) }
                 itemList = item.map { it?.songList }
             }
 
@@ -105,7 +106,7 @@ class GeneralSubFragment : BaseFragment(true) {
                 // Dates
                 val item = mainActivity.reader.dateListFlow.map { it.find { it.id == id } }
                 title = item.map { it?.title ?: requireContext().getString(R.string.unknown_year) }
-                qTitle = title
+                qTitle = title.map { QueueTitle.Custom(it) }
                 itemList = item.map { it?.songList }
             }
 
@@ -138,7 +139,16 @@ class GeneralSubFragment : BaseFragment(true) {
                                 + if (it != null) " (${it.id} - ${it.path})" else "")
                     }
                 }
-                qTitle = title
+                qTitle = item.map {
+                    when {
+                        it is RecentlyAdded -> QueueTitle.Resource(R.string.recently_added)
+                        it is Favorite -> QueueTitle.Resource(R.string.playlist_favourite)
+                        else -> QueueTitle.Custom(
+                            it?.title ?: (requireContext().getString(R.string.unknown_playlist)
+                                    + if (it != null) " (${it.id} - ${it.path})" else "")
+                        )
+                    }
+                }
                 itemList = item.map { it?.songList }
                 rawOrderExposed = Sorter.Type.NaturalOrder
                 if (clazz == Playlist::class.java.name) {

--- a/app/src/main/java/org/akanework/gramophone/ui/fragments/ViewPagerFragment.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/fragments/ViewPagerFragment.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.akanework.gramophone.R
+import org.akanework.gramophone.logic.QueueTitle
 import org.akanework.gramophone.logic.clone
 import org.akanework.gramophone.logic.enableEdgeToEdgePaddingListener
 import org.akanework.gramophone.logic.needsManualSnackBarInset
@@ -194,7 +195,7 @@ class ViewPagerFragment : BaseFragment(true) {
                         ?.also {
                             controller?.shuffleModeEnabled = true
                             controller?.setMediaItems(
-                                queueWithTitle(it, context?.getString(R.string.category_songs))
+                                queueWithTitle(it, QueueTitle.Resource(R.string.category_songs))
                             )
                             controller?.prepare()
                             controller?.play()

--- a/app/src/main/java/org/akanework/gramophone/ui/fragments/compose/MultiQueue.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/fragments/compose/MultiQueue.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.akanework.gramophone.R
+import org.akanework.gramophone.logic.QueueTitle
 import org.akanework.gramophone.logic.MultiQueueObject
 import org.akanework.gramophone.logic.deleteQueue
 import org.akanework.gramophone.logic.getInactiveQueues
@@ -103,6 +104,7 @@ fun MqListItem(
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = {},
 ) {
+    val context = LocalContext.current
     Row( // wrapper
         modifier = modifier
             .padding(horizontal = 16.dp)
@@ -147,7 +149,7 @@ fun MqListItem(
                     }
                 }
                 Text(
-                    text = "${index + 1}. ${mq.title}",
+                    text = "${index + 1}. ${mq.title.resolve(context)}",
                     maxLines = 1,
                     overflow = TextOverflow.MiddleEllipsis,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 0.dp)
@@ -246,7 +248,7 @@ fun QueueInfo(
                 }
         ) {
             Text(
-                text = mqState.getQueueTitle() ?: "",
+                text = mqState.getQueueTitle(LocalContext.current) ?: "",
                 style = MaterialTheme.typography.titleMedium,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
@@ -751,11 +753,11 @@ class MqState(
 
     fun getQueueListSize(): Int = inactiveQueues.size + if (activeQueue == null) 0 else 1
 
-    fun getQueueTitle(): String? {
+    fun getQueueTitle(context: android.content.Context): String? {
         return if (!isDetached()) {
-            activeQueue?.title
+            activeQueue?.title?.resolve(context)
         } else {
-            detachedQueue?.title
+            detachedQueue?.title?.resolve(context)
         }
     }
 


### PR DESCRIPTION
## Summary

- Introduce a `QueueTitle` sealed class with two variants: `Resource(@StringRes val resId: Int)` for system-generated titles and `Custom(val name: String)` for user-defined names.
- Replace `MultiQueueObject.title: String` with `MultiQueueObject.title: QueueTitle`; update Bundle serialization with backward-compatible fallback for legacy state.
- Update `AdapterFragment.getQueueTitle()`, `GeneralSubFragment`, `SongAdapter`, `AlbumAdapter`, `ViewPagerFragment`, and `GramophonePlaybackService` to produce and consume `QueueTitle` values instead of resolved strings.
- Resolve titles to display strings at render time in `MqListItem` and `MqState.getQueueTitle(context)` via `QueueTitle.resolve(context)`.

## Why this matters

Queue titles like "Songs" or "Albums" were previously resolved once via `getString()` at the moment a song was played, then baked into `MultiQueueObject.title` as a plain `String`. This prevented proper localization on locale change. See #943.

## Testing

- Play a song from each main tab (Songs, Albums, Genres, Dates, Folders, Playlists) and confirm the queue title shown in the multi-queue view matches the current locale's translation of that tab label.
- Rename a user playlist and play from it; the queue title should show the user-defined name, not a translated resource.
- Change device locale while a queue is active; after relaunching the multi-queue UI the system-generated title should reflect the new locale.
- Verify `MultiQueueObject.title` round-trips correctly through Bundle serialization; legacy saved state (plain string) falls back to `QueueTitle.Custom`.
- Confirm the `(+​)` extension queue suffix logic in `QueueBoard.addQueue` still appends correctly.

Fixes #943