### PR TITLE
fix: correctly handle Android Auto favorite command

### DIFF
--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -1539,6 +1539,10 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         }
     }
 
+    override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+        refreshMediaButtonCustomLayout()
+    }
+
     override fun onIsPlayingChanged(isPlaying: Boolean) {
         scheduleSendingLyrics(false)
         lastPlayedManager.save()


### PR DESCRIPTION
This PR fixes an issue where pressing the favourite button in Android Auto caused the screen to flicker without actually toggling the favourite status or updating the button's icon.

`GramophonePlaybackService` was missing an override for `onMediaMetadataChanged`, so when the song was added/removed from favourites, the custom layout sent to connected controllers (e.g., Android Auto) was never refreshed.

I've modified the playback service to hook onMediaMetadataChanged and trigger `refreshMediaButtonCustomLayout()`.