### PR TITLE
feat(lyrics): add notification lyrics support

### DIFF
--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -219,11 +219,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
     private lateinit var prefs: SharedPreferences
     private var lastSentHighlightedLyric: String? = null
     private var lastSentNotificationLyric: String? = null
-    private var isPausedFallback = false
-    private val pauseFallbackRunnable = Runnable {
-        isPausedFallback = true
-        sendLyricNow(false)
-    }
     private lateinit var afFormatTracker: AfFormatTracker
     private lateinit var rgAp: ReplayGainAudioProcessor
     private var rgMode = 0 // 0 = disabled, 1 = track, 2 = album, 3 = smart
@@ -331,11 +326,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         qb = QueueBoard(this)
         setListener(this)
         setMediaNotificationProvider(
-            MeiZuLyricsMediaNotificationProvider(
-                this,
-                tickerProvider = { lastSentHighlightedLyric },
-                notificationLyricProvider = { lastSentNotificationLyric }
-            )
+            MeiZuLyricsMediaNotificationProvider(this) { lastSentHighlightedLyric }
         )
         setForegroundServiceTimeoutMs(120000)
         setShowNotificationForEmptyPlayer(SHOW_NOTIFICATION_FOR_EMPTY_PLAYER_AFTER_STOP_OR_ERROR)
@@ -828,7 +819,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         scope.cancel()
         endedWorkaroundPlayer!!.stop()
         handler.removeCallbacks(timer)
-        handler.removeCallbacks(pauseFallbackRunnable)
         handler.removeCallbacks(sendLyrics)
         mediaSession!!.setOptOutOfMediaButtonPlaybackResumption(controller!!.currentTimeline.isEmpty)
         proxy?.let {
@@ -917,7 +907,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         var restart = false
         if (key == null || key == "notification_lyrics" || key == "status_bar_lyrics") {
             scheduleSendingLyrics(false)
-            endedWorkaroundPlayer?.invalidatePlayerState()
+            endedWorkaroundPlayer?.updateLyricNow()
         }
         if (key == null || key == "rg_mode") {
             rgMode = prefs.getStringStrict("rg_mode", "0")!!.toInt()
@@ -1535,11 +1525,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
     }
 
     override fun onPlaybackStateChanged(state: Int) {
-        if (state == Player.STATE_ENDED || state == Player.STATE_IDLE) {
-            isPausedFallback = true
-            handler.removeCallbacks(pauseFallbackRunnable)
-            sendLyricNow(false)
-        }
         if (state == Player.STATE_IDLE) {
             var changed = false
             if (afTrackFormat != null) {
@@ -1604,8 +1589,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
             //lyrics = null
             //scheduleSendingLyrics(true)
         }
-        isPausedFallback = false
-        handler.removeCallbacks(pauseFallbackRunnable)
         lastSentNotificationLyric = null
         lastSentHighlightedLyric = null
 
@@ -1643,13 +1626,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
     }
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
-        if (!isPlaying) {
-            handler.removeCallbacks(pauseFallbackRunnable)
-            handler.postDelayed(pauseFallbackRunnable, 3000L)
-        } else {
-            handler.removeCallbacks(pauseFallbackRunnable)
-            isPausedFallback = false
-        }
         scheduleSendingLyrics(false)
         lastPlayedManager.save()
     }
@@ -1795,7 +1771,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
 
     private fun getActiveNotificationLyric(): String? {
         val isNotificationLyricsEnabled = prefs.getBooleanStrict("notification_lyrics", false)
-        if (!isNotificationLyricsEnabled || isPausedFallback) return null
+        if (!isNotificationLyricsEnabled) return null
         if (controller?.playbackState == Player.STATE_ENDED || controller?.playbackState == Player.STATE_IDLE) return null
 
         val cPos = (controller?.contentPosition ?: 0).toULong()
@@ -1851,7 +1827,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
             handler.post {
                 endedWorkaroundPlayer?.let {
                     if (notifLyricChanged) {
-                        it.invalidatePlayerState()
+                        it.updateLyricNow()
                     }
                     // This will access the media notification controller's getters. But because
                     // controller callback ordering is undefined and in practice our service

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -406,6 +406,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         onSharedPreferenceChanged(prefs, null) // read initial values
         val player = EndedWorkaroundPlayer(
             this,
+            prefs,
             exoPlayer = ExoPlayer.Builder(
                 this,
                 GramophoneRenderFactory(

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -137,6 +137,7 @@ import org.akanework.gramophone.logic.utils.exoplayer.GramophoneExtractorsFactor
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneMediaSourceFactory
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneRenderFactory
 import org.akanework.gramophone.ui.AudioPreviewActivity
+import org.akanework.gramophone.ui.CardWidgetProvider
 import org.akanework.gramophone.ui.LyricWidgetProvider
 import org.akanework.gramophone.ui.MainActivity
 import org.akanework.gramophone.ui.fragments.compose.MqState.Companion.CLIENT_QB_REFRESH_ALL
@@ -218,6 +219,12 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
     private lateinit var lastPlayedManager: LastPlayedManager
     private lateinit var prefs: SharedPreferences
     private var lastSentHighlightedLyric: String? = null
+    private var lastSentNotificationLyric: String? = null
+    private var isPausedFallback = false
+    private val pauseFallbackRunnable = Runnable {
+        isPausedFallback = true
+        sendLyricNow(false)
+    }
     private lateinit var afFormatTracker: AfFormatTracker
     private lateinit var rgAp: ReplayGainAudioProcessor
     private var rgMode = 0 // 0 = disabled, 1 = track, 2 = album, 3 = smart
@@ -325,7 +332,11 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         qb = QueueBoard(this)
         setListener(this)
         setMediaNotificationProvider(
-            MeiZuLyricsMediaNotificationProvider(this) { lastSentHighlightedLyric }
+            MeiZuLyricsMediaNotificationProvider(
+                this,
+                tickerProvider = { lastSentHighlightedLyric },
+                notificationLyricProvider = { lastSentNotificationLyric }
+            )
         )
         setForegroundServiceTimeoutMs(120000)
         setShowNotificationForEmptyPlayer(SHOW_NOTIFICATION_FOR_EMPTY_PLAYER_AFTER_STOP_OR_ERROR)
@@ -452,6 +463,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
                 .build(),
             { lyrics },
             queueBoard = qb,
+            getNotificationLyric = { lastSentNotificationLyric }
         )
         player.exoPlayer.addAnalyticsListener(EventLogger())
         player.exoPlayer.addAnalyticsListener(afFormatTracker)
@@ -804,6 +816,56 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         return onSetRating(session, controller, mediaItemId, rating)
     }
 
+    fun toggleCurrentItemFavorite() {
+        val item = endedWorkaroundPlayer?.currentMediaItem ?: return
+        val currentIsHeart = (item.mediaMetadata.userRating as? HeartRating)?.isHeart == true
+        val newIsHeart = !currentIsHeart
+        lifecycleScope.launch(Dispatchers.Default) {
+            val song = Entry.ofMediaItem(item) ?: return@launch
+            val uriIn = gramophoneApplication.reader.playlistListFlow.map { it.find { p ->
+                p is Favorite } }.first()?.id?.let {
+                ContentUris.withAppendedId(@Suppress("deprecation")
+                MediaStore.Audio.Playlists.EXTERNAL_CONTENT_URI, it)
+            }
+            val token = if (uriIn != null) {
+                MediaStoreCompat.needRequestBytesWrite(this@GramophonePlaybackService, uriIn)
+            } else {
+                MediaStoreCompat.needRequestCreate(this@GramophonePlaybackService,
+                    ItemManipulator.getDefaultPlaylistFile(ItemManipulator.FAVORITES).path)
+            }
+            if (token == null) {
+                try {
+                    val uri = uriIn ?: ItemManipulator.createPlaylist(
+                        this@GramophonePlaybackService, ItemManipulator
+                            .getDefaultPlaylistFile(ItemManipulator.FAVORITES))
+                    val readback = if (uriIn != null) ItemManipulator.readbackPlaylist(
+                        this@GramophonePlaybackService, uri) else
+                            PlaylistSerializer.Playlist.create()
+                    val newSongs = if (newIsHeart) {
+                        readback.entries + song
+                    } else {
+                        readback.entries.filter { !song.fuzzyEquals(it) }
+                    }
+                    ItemManipulator.setPlaylistContent(this@GramophonePlaybackService, uri,
+                        readback.copy(entries = newSongs), uriIn == null)
+                } catch (e: Exception) {
+                    Log.e(TAG, "failed to toggle favorite on ${item.mediaId}", e)
+                }
+            }
+            withContext(Dispatchers.Main) {
+                val updatedItem = item.buildUpon().setMediaMetadata(
+                    item.mediaMetadata.buildUpon()
+                        .setUserRating(HeartRating(newIsHeart))
+                        .build()
+                ).build()
+                val currentIndex = endedWorkaroundPlayer?.currentMediaItemIndex ?: 0
+                endedWorkaroundPlayer?.replaceMediaItem(currentIndex, updatedItem)
+                CardWidgetProvider.update(this@GramophonePlaybackService)
+            }
+        }
+    }
+
+
     // When destroying, we should release server side player
     // alongside with the mediaSession.
     override fun onDestroy() {
@@ -817,6 +879,8 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         scope.cancel()
         endedWorkaroundPlayer!!.stop()
         handler.removeCallbacks(timer)
+        handler.removeCallbacks(pauseFallbackRunnable)
+        handler.removeCallbacks(sendLyrics)
         mediaSession!!.setOptOutOfMediaButtonPlaybackResumption(controller!!.currentTimeline.isEmpty)
         proxy?.let {
             it.adapter.closeProfileProxy(BluetoothProfile.A2DP, it.a2dp)
@@ -828,6 +892,7 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         mediaSession = null
         broadcastAudioSessionClose()
         LyricWidgetProvider.update(this)
+        CardWidgetProvider.update(this)
         internalPlaybackThread.quitSafely()
         super.onDestroy()
         Log.i(TAG, "-onDestroy()")
@@ -902,6 +967,10 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         var restart = false
+        if (key == null || key == "notification_lyrics" || key == "status_bar_lyrics") {
+            scheduleSendingLyrics(false)
+            endedWorkaroundPlayer?.invalidatePlayerState()
+        }
         if (key == null || key == "rg_mode") {
             rgMode = prefs.getStringStrict("rg_mode", "0")!!.toInt()
             restart = !computeRgMode(true)
@@ -1518,6 +1587,11 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
     }
 
     override fun onPlaybackStateChanged(state: Int) {
+        if (state == Player.STATE_ENDED || state == Player.STATE_IDLE) {
+            isPausedFallback = true
+            handler.removeCallbacks(pauseFallbackRunnable)
+            sendLyricNow(false)
+        }
         if (state == Player.STATE_IDLE) {
             var changed = false
             if (afTrackFormat != null) {
@@ -1582,6 +1656,10 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
             //lyrics = null
             //scheduleSendingLyrics(true)
         }
+        isPausedFallback = false
+        handler.removeCallbacks(pauseFallbackRunnable)
+        lastSentNotificationLyric = null
+        lastSentHighlightedLyric = null
 
         // reshuffle queue when shuffle AND repeat all are enabled
         val player = endedWorkaroundPlayer
@@ -1617,6 +1695,13 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
     }
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
+        if (!isPlaying) {
+            handler.removeCallbacks(pauseFallbackRunnable)
+            handler.postDelayed(pauseFallbackRunnable, 3000L)
+        } else {
+            handler.removeCallbacks(pauseFallbackRunnable)
+            isPausedFallback = false
+        }
         scheduleSendingLyrics(false)
         lastPlayedManager.save()
     }
@@ -1760,6 +1845,20 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         scheduleSendingLyrics(false)
     }
 
+    private fun getActiveNotificationLyric(): String? {
+        val isNotificationLyricsEnabled = prefs.getBooleanStrict("notification_lyrics", false)
+        if (!isNotificationLyricsEnabled || isPausedFallback) return null
+        if (controller?.playbackState == Player.STATE_ENDED || controller?.playbackState == Player.STATE_IDLE) return null
+
+        val cPos = (controller?.contentPosition ?: 0).toULong()
+        val lines = syncedLyrics?.text?.filter {
+            it.start <= cPos && !it.isTranslated
+        }
+        val currentLine = lines?.maxByOrNull { it.start } ?: return null
+        if (currentLine.text.isBlank()) return null
+        return currentLine.text
+    }
+
     private fun scheduleSendingLyrics(new: Boolean) {
         handler.removeCallbacks(sendLyrics)
         sendLyricNow(new || !updatedLyricAtLeastOnce)
@@ -1767,38 +1866,53 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         if (new) {
             endedWorkaroundPlayer?.updateLyricNow()
         }
+        val hasCardWidget = CardWidgetProvider.hasWidget(this)
         val isStatusBarLyricsEnabled = prefs.getBooleanStrict("status_bar_lyrics", false)
+        val isNotificationLyricsEnabled = prefs.getBooleanStrict("notification_lyrics", false)
         val hnw = !LyricWidgetProvider.hasWidget(this)
-        if (controller?.isPlaying != true || (!isStatusBarLyricsEnabled && hnw)) return
+        if (controller?.isPlaying != true || (!isStatusBarLyricsEnabled && !isNotificationLyricsEnabled && hnw && !hasCardWidget)) return
         val cPos = (controller?.contentPosition ?: 0).toULong()
         val nextUpdate = syncedLyrics?.text?.flatMap { line ->
             if (hnw && line.start <= cPos) listOf() else if (hnw) listOf(line.start) else
                 (line.words?.map { it.timeRange.first }?.filter { it > cPos } ?: listOf())
                     .let { i -> if (line.start > cPos) i + line.start else i }
         }?.minOrNull()
-        nextUpdate?.let {
-            handler.postDelayed(
-                sendLyrics, ((it - cPos).toLong()
-                        / (controller?.playbackParameters?.speed ?: 1f)).toLong()
-            )
+        val delayMs = if (nextUpdate != null) {
+            val diff = ((nextUpdate - cPos).toLong() / (controller?.playbackParameters?.speed ?: 1f)).toLong()
+            if (hasCardWidget) diff.coerceAtMost(1000L).coerceAtLeast(500L) else diff
+        } else if (hasCardWidget) {
+            1000L
+        } else null
+
+        delayMs?.let {
+            handler.postDelayed(sendLyrics, it)
         }
     }
 
     private fun sendLyricNow(new: Boolean) {
-        if (new)
+        if (new) {
             LyricWidgetProvider.update(this)
-        else
+            CardWidgetProvider.update(this)
+        } else {
             LyricWidgetProvider.adapterUpdate(this)
+            CardWidgetProvider.update(this)
+        }
         val isStatusBarLyricsEnabled = prefs.getBooleanStrict("status_bar_lyrics", false)
         val highlightedLyric = if (isStatusBarLyricsEnabled && controller?.playWhenReady == true)
             getCurrentLyricIndex(false)?.let {
                 syncedLyrics?.text?.get(it)?.text
             }
         else null
-        if (lastSentHighlightedLyric != highlightedLyric) {
+        val notificationLyric = getActiveNotificationLyric()
+        if (lastSentHighlightedLyric != highlightedLyric || lastSentNotificationLyric != notificationLyric) {
+            val notifLyricChanged = lastSentNotificationLyric != notificationLyric
             lastSentHighlightedLyric = highlightedLyric
+            lastSentNotificationLyric = notificationLyric
             handler.post {
                 endedWorkaroundPlayer?.let {
+                    if (notifLyricChanged) {
+                        it.invalidatePlayerState()
+                    }
                     // This will access the media notification controller's getters. But because
                     // controller callback ordering is undefined and in practice our service
                     // controller sometimes gets called first, this would cause us to access a stale

--- a/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/GramophonePlaybackService.kt
@@ -137,7 +137,6 @@ import org.akanework.gramophone.logic.utils.exoplayer.GramophoneExtractorsFactor
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneMediaSourceFactory
 import org.akanework.gramophone.logic.utils.exoplayer.GramophoneRenderFactory
 import org.akanework.gramophone.ui.AudioPreviewActivity
-import org.akanework.gramophone.ui.CardWidgetProvider
 import org.akanework.gramophone.ui.LyricWidgetProvider
 import org.akanework.gramophone.ui.MainActivity
 import org.akanework.gramophone.ui.fragments.compose.MqState.Companion.CLIENT_QB_REFRESH_ALL
@@ -816,56 +815,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         return onSetRating(session, controller, mediaItemId, rating)
     }
 
-    fun toggleCurrentItemFavorite() {
-        val item = endedWorkaroundPlayer?.currentMediaItem ?: return
-        val currentIsHeart = (item.mediaMetadata.userRating as? HeartRating)?.isHeart == true
-        val newIsHeart = !currentIsHeart
-        lifecycleScope.launch(Dispatchers.Default) {
-            val song = Entry.ofMediaItem(item) ?: return@launch
-            val uriIn = gramophoneApplication.reader.playlistListFlow.map { it.find { p ->
-                p is Favorite } }.first()?.id?.let {
-                ContentUris.withAppendedId(@Suppress("deprecation")
-                MediaStore.Audio.Playlists.EXTERNAL_CONTENT_URI, it)
-            }
-            val token = if (uriIn != null) {
-                MediaStoreCompat.needRequestBytesWrite(this@GramophonePlaybackService, uriIn)
-            } else {
-                MediaStoreCompat.needRequestCreate(this@GramophonePlaybackService,
-                    ItemManipulator.getDefaultPlaylistFile(ItemManipulator.FAVORITES).path)
-            }
-            if (token == null) {
-                try {
-                    val uri = uriIn ?: ItemManipulator.createPlaylist(
-                        this@GramophonePlaybackService, ItemManipulator
-                            .getDefaultPlaylistFile(ItemManipulator.FAVORITES))
-                    val readback = if (uriIn != null) ItemManipulator.readbackPlaylist(
-                        this@GramophonePlaybackService, uri) else
-                            PlaylistSerializer.Playlist.create()
-                    val newSongs = if (newIsHeart) {
-                        readback.entries + song
-                    } else {
-                        readback.entries.filter { !song.fuzzyEquals(it) }
-                    }
-                    ItemManipulator.setPlaylistContent(this@GramophonePlaybackService, uri,
-                        readback.copy(entries = newSongs), uriIn == null)
-                } catch (e: Exception) {
-                    Log.e(TAG, "failed to toggle favorite on ${item.mediaId}", e)
-                }
-            }
-            withContext(Dispatchers.Main) {
-                val updatedItem = item.buildUpon().setMediaMetadata(
-                    item.mediaMetadata.buildUpon()
-                        .setUserRating(HeartRating(newIsHeart))
-                        .build()
-                ).build()
-                val currentIndex = endedWorkaroundPlayer?.currentMediaItemIndex ?: 0
-                endedWorkaroundPlayer?.replaceMediaItem(currentIndex, updatedItem)
-                CardWidgetProvider.update(this@GramophonePlaybackService)
-            }
-        }
-    }
-
-
     // When destroying, we should release server side player
     // alongside with the mediaSession.
     override fun onDestroy() {
@@ -892,7 +841,6 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         mediaSession = null
         broadcastAudioSessionClose()
         LyricWidgetProvider.update(this)
-        CardWidgetProvider.update(this)
         internalPlaybackThread.quitSafely()
         super.onDestroy()
         Log.i(TAG, "-onDestroy()")
@@ -1866,37 +1814,29 @@ class GramophonePlaybackService : MediaLibraryService(), MediaSessionService.Lis
         if (new) {
             endedWorkaroundPlayer?.updateLyricNow()
         }
-        val hasCardWidget = CardWidgetProvider.hasWidget(this)
         val isStatusBarLyricsEnabled = prefs.getBooleanStrict("status_bar_lyrics", false)
         val isNotificationLyricsEnabled = prefs.getBooleanStrict("notification_lyrics", false)
         val hnw = !LyricWidgetProvider.hasWidget(this)
-        if (controller?.isPlaying != true || (!isStatusBarLyricsEnabled && !isNotificationLyricsEnabled && hnw && !hasCardWidget)) return
+        if (controller?.isPlaying != true || (!isStatusBarLyricsEnabled && !isNotificationLyricsEnabled && hnw)) return
         val cPos = (controller?.contentPosition ?: 0).toULong()
         val nextUpdate = syncedLyrics?.text?.flatMap { line ->
             if (hnw && line.start <= cPos) listOf() else if (hnw) listOf(line.start) else
                 (line.words?.map { it.timeRange.first }?.filter { it > cPos } ?: listOf())
                     .let { i -> if (line.start > cPos) i + line.start else i }
         }?.minOrNull()
-        val delayMs = if (nextUpdate != null) {
-            val diff = ((nextUpdate - cPos).toLong() / (controller?.playbackParameters?.speed ?: 1f)).toLong()
-            if (hasCardWidget) diff.coerceAtMost(1000L).coerceAtLeast(500L) else diff
-        } else if (hasCardWidget) {
-            1000L
-        } else null
-
-        delayMs?.let {
-            handler.postDelayed(sendLyrics, it)
+        nextUpdate?.let {
+            handler.postDelayed(
+                sendLyrics, ((it - cPos).toLong()
+                        / (controller?.playbackParameters?.speed ?: 1f)).toLong()
+            )
         }
     }
 
     private fun sendLyricNow(new: Boolean) {
-        if (new) {
+        if (new)
             LyricWidgetProvider.update(this)
-            CardWidgetProvider.update(this)
-        } else {
+        else
             LyricWidgetProvider.adapterUpdate(this)
-            CardWidgetProvider.update(this)
-        }
         val isStatusBarLyricsEnabled = prefs.getBooleanStrict("status_bar_lyrics", false)
         val highlightedLyric = if (isStatusBarLyricsEnabled && controller?.playWhenReady == true)
             getCurrentLyricIndex(false)?.let {

--- a/app/src/main/java/org/akanework/gramophone/logic/ui/MeiZuLyricsMediaNotificationProvider.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/ui/MeiZuLyricsMediaNotificationProvider.kt
@@ -35,8 +35,7 @@ private const val FLAG_ONLY_UPDATE_TICKER = 0x02000000
 
 private class InnerMeiZuLyricsMediaNotificationProvider(
     context: Context,
-    private val tickerProvider: () -> CharSequence?,
-    private val notificationLyricProvider: () -> CharSequence?
+    private val tickerProvider: () -> CharSequence?
 ) : DefaultMediaNotificationProvider(context) {
     override fun addNotificationActions(
         mediaSession: MediaSession,
@@ -45,7 +44,6 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
         actionFactory: MediaNotification.ActionFactory
     ): IntArray {
         val ticker = tickerProvider()
-        val notifLyric = notificationLyricProvider()
         val title = mediaSession.player.mediaMetadata.title?.toString() ?: ""
         val artist = mediaSession.player.mediaMetadata.artist?.toString() ?: ""
 
@@ -64,22 +62,15 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
                 putBoolean("ticker_icon_switch", false)
             })
         }
-        if (!notifLyric.isNullOrBlank()) {
-            val subtitle = if (artist.isNotBlank() && title.isNotBlank()) "$artist - $title" else artist.ifBlank { title }
-            builder.setContentTitle(notifLyric)
-            builder.setContentText(subtitle)
-            builder.setSubText(subtitle)
-        }
         return super.addNotificationActions(mediaSession, mediaButtons, builder, actionFactory)
     }
 }
 
 class MeiZuLyricsMediaNotificationProvider(
     context: MediaSessionService,
-    private val tickerProvider: () -> CharSequence?,
-    private val notificationLyricProvider: () -> CharSequence? = { null },
+    private val tickerProvider: () -> CharSequence?
 ) : MediaNotification.Provider {
-    private val inner = InnerMeiZuLyricsMediaNotificationProvider(context, tickerProvider, notificationLyricProvider).apply {
+    private val inner = InnerMeiZuLyricsMediaNotificationProvider(context, tickerProvider).apply {
         setSmallIcon(R.drawable.ic_gramophone_monochrome)
     }
 
@@ -90,7 +81,6 @@ class MeiZuLyricsMediaNotificationProvider(
         onNotificationChangedCallback: MediaNotification.Provider.Callback
     ): MediaNotification {
         val ticker = tickerProvider()
-        val notifLyric = notificationLyricProvider()
         return inner.createNotification(
             mediaSession, customLayout, actionFactory
         ) {
@@ -99,9 +89,8 @@ class MeiZuLyricsMediaNotificationProvider(
                     it.applyNotificationFlags(true, false)
             })
         }.also {
-            val updateTickerOnly = isManualNotificationUpdate && notifLyric == null
             if (ticker != null || isManualNotificationUpdate)
-                it.applyNotificationFlags(ticker != null, updateTickerOnly)
+                it.applyNotificationFlags(ticker != null, isManualNotificationUpdate)
         }
     }
 

--- a/app/src/main/java/org/akanework/gramophone/logic/ui/MeiZuLyricsMediaNotificationProvider.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/ui/MeiZuLyricsMediaNotificationProvider.kt
@@ -35,7 +35,8 @@ private const val FLAG_ONLY_UPDATE_TICKER = 0x02000000
 
 private class InnerMeiZuLyricsMediaNotificationProvider(
     context: Context,
-    private val tickerProvider: () -> CharSequence?
+    private val tickerProvider: () -> CharSequence?,
+    private val notificationLyricProvider: () -> CharSequence?
 ) : DefaultMediaNotificationProvider(context) {
     override fun addNotificationActions(
         mediaSession: MediaSession,
@@ -44,8 +45,9 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
         actionFactory: MediaNotification.ActionFactory
     ): IntArray {
         val ticker = tickerProvider()
-        val title = mediaSession.player.mediaMetadata.title.toString()
-        val artist = mediaSession.player.mediaMetadata.artist.toString()
+        val notifLyric = notificationLyricProvider()
+        val title = mediaSession.player.mediaMetadata.title?.toString() ?: ""
+        val artist = mediaSession.player.mediaMetadata.artist?.toString() ?: ""
 
         val bundle = IsLandHelp.isLandMusicShare(
             addpic = Bundle(),
@@ -62,6 +64,12 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
                 putBoolean("ticker_icon_switch", false)
             })
         }
+        if (!notifLyric.isNullOrBlank()) {
+            val subtitle = if (artist.isNotBlank() && title.isNotBlank()) "$artist - $title" else artist.ifBlank { title }
+            builder.setContentTitle(notifLyric)
+            builder.setContentText(subtitle)
+            builder.setSubText(subtitle)
+        }
         return super.addNotificationActions(mediaSession, mediaButtons, builder, actionFactory)
     }
 }
@@ -69,8 +77,9 @@ private class InnerMeiZuLyricsMediaNotificationProvider(
 class MeiZuLyricsMediaNotificationProvider(
     context: MediaSessionService,
     private val tickerProvider: () -> CharSequence?,
+    private val notificationLyricProvider: () -> CharSequence? = { null },
 ) : MediaNotification.Provider {
-    private val inner = InnerMeiZuLyricsMediaNotificationProvider(context, tickerProvider).apply {
+    private val inner = InnerMeiZuLyricsMediaNotificationProvider(context, tickerProvider, notificationLyricProvider).apply {
         setSmallIcon(R.drawable.ic_gramophone_monochrome)
     }
 
@@ -81,6 +90,7 @@ class MeiZuLyricsMediaNotificationProvider(
         onNotificationChangedCallback: MediaNotification.Provider.Callback
     ): MediaNotification {
         val ticker = tickerProvider()
+        val notifLyric = notificationLyricProvider()
         return inner.createNotification(
             mediaSession, customLayout, actionFactory
         ) {
@@ -89,8 +99,9 @@ class MeiZuLyricsMediaNotificationProvider(
                     it.applyNotificationFlags(true, false)
             })
         }.also {
+            val updateTickerOnly = isManualNotificationUpdate && notifLyric == null
             if (ticker != null || isManualNotificationUpdate)
-                it.applyNotificationFlags(ticker != null, isManualNotificationUpdate)
+                it.applyNotificationFlags(ticker != null, updateTickerOnly)
         }
     }
 

--- a/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
@@ -27,6 +27,7 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.util.Log
 import androidx.media3.exoplayer.ExoPlayer
+import android.content.SharedPreferences
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import org.akanework.gramophone.BuildConfig
@@ -38,7 +39,6 @@ import org.akanework.gramophone.logic.utils.CircularShuffleOrder
 import org.akanework.gramophone.logic.utils.Flags
 import org.akanework.gramophone.logic.utils.SemanticLyrics
 import org.json.JSONObject
-import androidx.preference.PreferenceManager
 import org.akanework.gramophone.logic.getBooleanStrict
 import uk.akane.libphonograph.items.EXTRA_HD_ARTWORK_URI
 import uk.akane.libphonograph.items.hdArtworkUri
@@ -52,6 +52,7 @@ import java.util.Objects
  */
 class EndedWorkaroundPlayer(
     val context: Context,
+    private val prefs: SharedPreferences,
     exoPlayer: ExoPlayer,
     private val getLyric: () -> SemanticLyrics?,
     val queueBoard: QueueBoard,
@@ -100,8 +101,7 @@ class EndedWorkaroundPlayer(
     }
 
     fun updateLyricNow() {
-        val isNotificationLyricsEnabled = PreferenceManager.getDefaultSharedPreferences(context)
-            .getBooleanStrict("notification_lyrics", false)
+        val isNotificationLyricsEnabled = prefs.getBooleanStrict("notification_lyrics", false)
         if (context.packageName == "com.tencent.qqmusic" || isNotificationLyricsEnabled) {
             invalidateState()
         }

--- a/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
@@ -38,6 +38,8 @@ import org.akanework.gramophone.logic.utils.CircularShuffleOrder
 import org.akanework.gramophone.logic.utils.Flags
 import org.akanework.gramophone.logic.utils.SemanticLyrics
 import org.json.JSONObject
+import androidx.preference.PreferenceManager
+import org.akanework.gramophone.logic.getBooleanStrict
 import uk.akane.libphonograph.items.EXTRA_HD_ARTWORK_URI
 import uk.akane.libphonograph.items.hdArtworkUri
 import java.util.Objects
@@ -98,11 +100,11 @@ class EndedWorkaroundPlayer(
     }
 
     fun updateLyricNow() {
-        invalidateState()
-    }
-
-    fun invalidatePlayerState() {
-        invalidateState()
+        val isNotificationLyricsEnabled = PreferenceManager.getDefaultSharedPreferences(context)
+            .getBooleanStrict("notification_lyrics", false)
+        if (context.packageName == "com.tencent.qqmusic" || isNotificationLyricsEnabled) {
+            invalidateState()
+        }
     }
 
     override fun getState(): State {
@@ -122,28 +124,30 @@ class EndedWorkaroundPlayer(
                 )
                 .build()
         }
-        val notifLyric = getNotificationLyric()
-        if (!notifLyric.isNullOrBlank()) {
-            val origTitle = superState.currentMetadata.title?.toString() ?: ""
-            val origArtist = superState.currentMetadata.artist?.toString() ?: ""
-            val subtitle = if (origArtist.isNotBlank() && origTitle.isNotBlank()) {
-                "$origArtist - $origTitle"
-            } else {
-                origArtist.ifBlank { origTitle }
+        if (superState.playWhenReady && superState.playbackState != STATE_ENDED && superState.playbackState != STATE_IDLE) {
+            val notifLyric = getNotificationLyric()
+            if (!notifLyric.isNullOrBlank()) {
+                val origTitle = superState.currentMetadata.title?.toString() ?: ""
+                val origArtist = superState.currentMetadata.artist?.toString() ?: ""
+                val subtitle = if (origArtist.isNotBlank() && origTitle.isNotBlank()) {
+                    "$origArtist - $origTitle"
+                } else {
+                    origArtist.ifBlank { origTitle }
+                }
+                val metadataWithLyric = superState.currentMetadata.buildUpon()
+                    .setTitle(notifLyric)
+                    .setArtist(subtitle)
+                    .setDisplayTitle(notifLyric)
+                    .setSubtitle(subtitle)
+                    .build()
+                superState = superState.buildUpon()
+                    .setPlaylist(
+                        superState.timeline,
+                        superState.currentTracks,
+                        metadataWithLyric
+                    )
+                    .build()
             }
-            val metadataWithLyric = superState.currentMetadata.buildUpon()
-                .setTitle(notifLyric)
-                .setArtist(subtitle)
-                .setDisplayTitle(notifLyric)
-                .setSubtitle(subtitle)
-                .build()
-            superState = superState.buildUpon()
-                .setPlaylist(
-                    superState.timeline,
-                    superState.currentTracks,
-                    metadataWithLyric
-                )
-                .build()
         }
         if (context.packageName == "com.tencent.qqmusic") {
             // Oplus uses package name whitelist for their lockscreen lyric feature

--- a/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
@@ -52,7 +52,8 @@ class EndedWorkaroundPlayer(
     val context: Context,
     exoPlayer: ExoPlayer,
     private val getLyric: () -> SemanticLyrics?,
-    val queueBoard: QueueBoard
+    val queueBoard: QueueBoard,
+    private val getNotificationLyric: () -> CharSequence? = { null }
 ) : ForwardingSimpleBasePlayer(exoPlayer),
     Player.Listener {
 
@@ -97,9 +98,11 @@ class EndedWorkaroundPlayer(
     }
 
     fun updateLyricNow() {
-        if (context.packageName == "com.tencent.qqmusic") {
-            invalidateState()
-        }
+        invalidateState()
+    }
+
+    fun invalidatePlayerState() {
+        invalidateState()
     }
 
     override fun getState(): State {
@@ -116,6 +119,29 @@ class EndedWorkaroundPlayer(
                             remove(EXTRA_HD_ARTWORK_URI)
                         })
                         .build()
+                )
+                .build()
+        }
+        val notifLyric = getNotificationLyric()
+        if (!notifLyric.isNullOrBlank()) {
+            val origTitle = superState.currentMetadata.title?.toString() ?: ""
+            val origArtist = superState.currentMetadata.artist?.toString() ?: ""
+            val subtitle = if (origArtist.isNotBlank() && origTitle.isNotBlank()) {
+                "$origArtist - $origTitle"
+            } else {
+                origArtist.ifBlank { origTitle }
+            }
+            val metadataWithLyric = superState.currentMetadata.buildUpon()
+                .setTitle(notifLyric)
+                .setArtist(subtitle)
+                .setDisplayTitle(notifLyric)
+                .setSubtitle(subtitle)
+                .build()
+            superState = superState.buildUpon()
+                .setPlaylist(
+                    superState.timeline,
+                    superState.currentTracks,
+                    metadataWithLyric
                 )
                 .build()
         }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -155,6 +155,8 @@
     <string name="tab_order_summary">应用将在启动时显示第一个标签页。分隔线后的标签页将被隐藏。</string>
     <string name="settings_status_bar_lyrics_title">状态栏歌词</string>
     <string name="settings_status_bar_lyrics_summary">启用魅族状态栏歌词（仅适用于部分设备）</string>
+    <string name="settings_notification_lyrics_title">通知栏歌词</string>
+    <string name="settings_notification_lyrics_summary">在媒体通知中显示当前播放歌词</string>
     <string name="settings_lyrics_ui">启用新歌词界面</string>
     <string name="lyric_widget_description">显示当前播放媒体歌词的小部件</string>
     <string name="scroll_to_albums">滚动到专辑</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -392,6 +392,10 @@
     <string name="settings_status_bar_lyrics_title">Status bar lyrics</string>
     <!-- Settings toggle to enable showing lyrics in status bar (requires meizu phone). Subtext -->
     <string name="settings_status_bar_lyrics_summary">Enable MeiZu method of displaying lyrics in status bar (only available on some devices)</string>
+    <!-- Settings toggle to enable showing lyrics in media notification. Title -->
+    <string name="settings_notification_lyrics_title">Notification lyrics</string>
+    <!-- Settings toggle to enable showing lyrics in media notification. Subtext -->
+    <string name="settings_notification_lyrics_summary">Display lyrics as the notification title and artist - title as subtitle</string>
     <!-- Description shown about lyric widget in Android launcher / home screen's widget selector on Android 12+ -->
     <string name="lyric_widget_description">Widget that shows lyrics of currently playing media</string>
     <!-- Context menu item to delete song/album/playlist -->

--- a/app/src/main/res/xml/settings_lyric.xml
+++ b/app/src/main/res/xml/settings_lyric.xml
@@ -56,6 +56,15 @@
         app:iconSpaceReserved="false" />
 
     <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="notification_lyrics"
+        android:layout="@layout/preference_switch"
+        android:summary="@string/settings_notification_lyrics_summary"
+        android:title="@string/settings_notification_lyrics_title"
+        android:widgetLayout="@layout/preference_switch_widget"
+        app:iconSpaceReserved="false" />
+
+    <SwitchPreferenceCompat
         android:defaultValue="true"
         android:key="trim_lyrics"
         android:layout="@layout/preference_switch"


### PR DESCRIPTION
## Summary

Notification lyrics — opt-in setting that surfaces the current synced lyric line in both the expanded media notification and the system media session metadata (lockscreen / BT / Android Auto), with the original title+artist preserved as the subtitle line.

Screenshots, CI tests and more, see #1003 