### PR TITLE
feat(behavior): add preference to always skip to previous track

### DIFF
--- a/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
@@ -99,18 +99,10 @@ class EndedWorkaroundPlayer(
     }
 
     fun updateLyricNow() {
-<<<<<<< HEAD
         val isNotificationLyricsEnabled = prefs.getBooleanStrict("notification_lyrics", false)
         if (context.packageName == "com.tencent.qqmusic" || isNotificationLyricsEnabled) {
             invalidateState()
         }
-=======
-        invalidateState()
-    }
-
-    fun invalidatePlayerState() {
-        invalidateState()
->>>>>>> b427b13e (feat(behavior): add preference to always skip to previous track)
     }
 
     override fun getState(): State {
@@ -130,7 +122,6 @@ class EndedWorkaroundPlayer(
                 )
                 .build()
         }
-<<<<<<< HEAD
         if (superState.playWhenReady && superState.playbackState != STATE_ENDED && superState.playbackState != STATE_IDLE) {
             val notifLyric = getNotificationLyric()
             if (!notifLyric.isNullOrBlank()) {
@@ -155,30 +146,6 @@ class EndedWorkaroundPlayer(
                     )
                     .build()
             }
-=======
-        val notifLyric = getNotificationLyric()
-        if (!notifLyric.isNullOrBlank()) {
-            val origTitle = superState.currentMetadata.title?.toString() ?: ""
-            val origArtist = superState.currentMetadata.artist?.toString() ?: ""
-            val subtitle = if (origArtist.isNotBlank() && origTitle.isNotBlank()) {
-                "$origArtist - $origTitle"
-            } else {
-                origArtist.ifBlank { origTitle }
-            }
-            val metadataWithLyric = superState.currentMetadata.buildUpon()
-                .setTitle(notifLyric)
-                .setArtist(subtitle)
-                .setDisplayTitle(notifLyric)
-                .setSubtitle(subtitle)
-                .build()
-            superState = superState.buildUpon()
-                .setPlaylist(
-                    superState.timeline,
-                    superState.currentTracks,
-                    metadataWithLyric
-                )
-                .build()
->>>>>>> b427b13e (feat(behavior): add preference to always skip to previous track)
         }
         if (context.packageName == "com.tencent.qqmusic") {
             // Oplus uses package name whitelist for their lockscreen lyric feature

--- a/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
+++ b/app/src/main/java/org/akanework/gramophone/logic/utils/exoplayer/EndedWorkaroundPlayer.kt
@@ -99,10 +99,18 @@ class EndedWorkaroundPlayer(
     }
 
     fun updateLyricNow() {
+<<<<<<< HEAD
         val isNotificationLyricsEnabled = prefs.getBooleanStrict("notification_lyrics", false)
         if (context.packageName == "com.tencent.qqmusic" || isNotificationLyricsEnabled) {
             invalidateState()
         }
+=======
+        invalidateState()
+    }
+
+    fun invalidatePlayerState() {
+        invalidateState()
+>>>>>>> b427b13e (feat(behavior): add preference to always skip to previous track)
     }
 
     override fun getState(): State {
@@ -122,6 +130,7 @@ class EndedWorkaroundPlayer(
                 )
                 .build()
         }
+<<<<<<< HEAD
         if (superState.playWhenReady && superState.playbackState != STATE_ENDED && superState.playbackState != STATE_IDLE) {
             val notifLyric = getNotificationLyric()
             if (!notifLyric.isNullOrBlank()) {
@@ -146,6 +155,30 @@ class EndedWorkaroundPlayer(
                     )
                     .build()
             }
+=======
+        val notifLyric = getNotificationLyric()
+        if (!notifLyric.isNullOrBlank()) {
+            val origTitle = superState.currentMetadata.title?.toString() ?: ""
+            val origArtist = superState.currentMetadata.artist?.toString() ?: ""
+            val subtitle = if (origArtist.isNotBlank() && origTitle.isNotBlank()) {
+                "$origArtist - $origTitle"
+            } else {
+                origArtist.ifBlank { origTitle }
+            }
+            val metadataWithLyric = superState.currentMetadata.buildUpon()
+                .setTitle(notifLyric)
+                .setArtist(subtitle)
+                .setDisplayTitle(notifLyric)
+                .setSubtitle(subtitle)
+                .build()
+            superState = superState.buildUpon()
+                .setPlaylist(
+                    superState.timeline,
+                    superState.currentTracks,
+                    metadataWithLyric
+                )
+                .build()
+>>>>>>> b427b13e (feat(behavior): add preference to always skip to previous track)
         }
         if (context.packageName == "com.tencent.qqmusic") {
             // Oplus uses package name whitelist for their lockscreen lyric feature
@@ -402,6 +435,20 @@ class EndedWorkaroundPlayer(
         )
         return Futures.immediateVoidFuture()
     }
+
+    override fun handleSeek(
+        mediaItemIndex: Int,
+        positionMs: Long,
+        seekCommand: Int
+    ): ListenableFuture<*> {
+        val alwaysSkipPrevious = prefs.getBooleanStrict("always_skip_previous", false)
+        if (seekCommand == Player.COMMAND_SEEK_TO_PREVIOUS && alwaysSkipPrevious) {
+            player.seekToPreviousMediaItem()
+            return Futures.immediateVoidFuture()
+        }
+        return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
+    }
+
 
 
     /**

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -153,12 +153,12 @@
     <string name="settings_preference_category_home">主屏幕</string>
     <string name="tab_order">配置标签页顺序</string>
     <string name="tab_order_summary">应用将在启动时显示第一个标签页。分隔线后的标签页将被隐藏。</string>
-    <string name="settings_always_skip_previous">总是跳至上一曲</string>
-    <string name="settings_always_skip_previous_summary">点按上一曲按钮时直接跳至上一首曲目，而非跳回开头</string>
     <string name="settings_status_bar_lyrics_title">状态栏歌词</string>
     <string name="settings_status_bar_lyrics_summary">启用魅族状态栏歌词（仅适用于部分设备）</string>
     <string name="settings_lyrics_ui">启用新歌词界面</string>
     <string name="lyric_widget_description">显示当前播放媒体歌词的小部件</string>
+    <string name="settings_always_skip_previous">总是跳至上一曲</string>
+    <string name="settings_always_skip_previous_summary">点按上一曲按钮时直接跳至上一首曲目，而非跳回开头</string>
     <string name="scroll_to_albums">滚动到专辑</string>
     <string name="scroll_to_songs">滚动到歌曲</string>
     <string name="expand_less">关闭</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -153,6 +153,8 @@
     <string name="settings_preference_category_home">主屏幕</string>
     <string name="tab_order">配置标签页顺序</string>
     <string name="tab_order_summary">应用将在启动时显示第一个标签页。分隔线后的标签页将被隐藏。</string>
+    <string name="settings_always_skip_previous">总是跳至上一曲</string>
+    <string name="settings_always_skip_previous_summary">点按上一曲按钮时直接跳至上一首曲目，而非跳回开头</string>
     <string name="settings_status_bar_lyrics_title">状态栏歌词</string>
     <string name="settings_status_bar_lyrics_summary">启用魅族状态栏歌词（仅适用于部分设备）</string>
     <string name="settings_lyrics_ui">启用新歌词界面</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,8 +231,10 @@
     <string name="settings_player_options_summary">Output quality, playback behavior</string>
     <!-- Settings category about customizing UI (currently disabled). Title -->
     <string name="settings_customization">Customization</string>
-    <!-- Settings category about customizing UI (currently disabled). Subtext -->
+    <!-- Settings category in behavior settings about customization options. Subtext -->
     <string name="settings_customization_summary">Manage customization options</string>
+    <string name="settings_always_skip_previous">Always skip to previous track</string>
+    <string name="settings_always_skip_previous_summary">Directly switch to previous track when pressing previous button instead of seeking to start</string>
     <!-- Pixel slider in behavior settings to specify how round album cover's corner should be. -->
     <string name="settings_album_round_corner">Album round corner</string>
     <!-- Toggle in player UI settings to make song name bold. Title -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,9 +231,11 @@
     <string name="settings_player_options_summary">Output quality, playback behavior</string>
     <!-- Settings category about customizing UI (currently disabled). Title -->
     <string name="settings_customization">Customization</string>
-    <!-- Settings category in behavior settings about customization options. Subtext -->
+    <!-- Settings category about customizing UI (currently disabled). Subtext -->
     <string name="settings_customization_summary">Manage customization options</string>
+    <!-- Settings toggle in behavior settings to always skip to previous track on previous button press. Title -->
     <string name="settings_always_skip_previous">Always skip to previous track</string>
+    <!-- Settings toggle in behavior settings to always skip to previous track on previous button press. Subtext -->
     <string name="settings_always_skip_previous_summary">Directly switch to previous track when pressing previous button instead of seeking to start</string>
     <!-- Pixel slider in behavior settings to specify how round album cover's corner should be. -->
     <string name="settings_album_round_corner">Album round corner</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,10 +233,6 @@
     <string name="settings_customization">Customization</string>
     <!-- Settings category about customizing UI (currently disabled). Subtext -->
     <string name="settings_customization_summary">Manage customization options</string>
-    <!-- Settings toggle in behavior settings to always skip to previous track on previous button press. Title -->
-    <string name="settings_always_skip_previous">Always skip to previous track</string>
-    <!-- Settings toggle in behavior settings to always skip to previous track on previous button press. Subtext -->
-    <string name="settings_always_skip_previous_summary">Directly switch to previous track when pressing previous button instead of seeking to start</string>
     <!-- Pixel slider in behavior settings to specify how round album cover's corner should be. -->
     <string name="settings_album_round_corner">Album round corner</string>
     <!-- Toggle in player UI settings to make song name bold. Title -->
@@ -402,6 +398,10 @@
     <string name="settings_notification_lyrics_summary">Display lyrics as the notification title and artist - title as subtitle</string>
     <!-- Description shown about lyric widget in Android launcher / home screen's widget selector on Android 12+ -->
     <string name="lyric_widget_description">Widget that shows lyrics of currently playing media</string>
+    <!-- Settings toggle in behavior settings to always skip to previous track on previous button press. Title -->
+    <string name="settings_always_skip_previous">Always skip to previous track</string>
+    <!-- Settings toggle in behavior settings to always skip to previous track on previous button press. Subtext -->
+    <string name="settings_always_skip_previous_summary">Directly switch to previous track when pressing previous button instead of seeking to start</string>
     <!-- Context menu item to delete song/album/playlist -->
     <string name="delete">Delete</string>
     <!-- Dialog text to confirm user wants to delete a specific song or playlist with user defined name -->

--- a/app/src/main/res/xml/settings_behavior.xml
+++ b/app/src/main/res/xml/settings_behavior.xml
@@ -71,6 +71,15 @@
             android:widgetLayout="@layout/preference_switch_widget"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="always_skip_previous"
+            android:layout="@layout/preference_switch"
+            android:summary="@string/settings_always_skip_previous_summary"
+            android:title="@string/settings_always_skip_previous"
+            android:widgetLayout="@layout/preference_switch_widget"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
## Summary

"Always skip to previous track" behavior — opt-in flag so pressing Previous jumps straight to the last item instead of seeking back to track start, useful for heads-free and hardware-button use cases.

Screenshots, CI tests and more, see https://github.com/FoedusProgramme/Gramophone/pull/1003